### PR TITLE
Fix mountains missing

### DIFF
--- a/src/components/EnvironmentSystem.tsx
+++ b/src/components/EnvironmentSystem.tsx
@@ -62,11 +62,11 @@ export const EnvironmentSystem: React.FC<EnvironmentSystemProps> = ({
       )}
       
       {/* Simplified terrain for sci-fi realm */}
-      <PixelTerrainSystem 
-        tier={currentTier} 
-        opacity={transitionOpacity} 
+      <PixelTerrainSystem
+        tier={currentTier}
+        opacity={transitionOpacity}
         excludeTrees={excludeTrees}
-        excludeMountains={realm === 'fantasy'}
+        excludeMountains={false}
       />
       
       {/* Minimal fog only for fantasy realm */}

--- a/src/components/FantasyReferenceEnvironment.tsx
+++ b/src/components/FantasyReferenceEnvironment.tsx
@@ -135,7 +135,7 @@ export const FantasyReferenceEnvironment: React.FC<FantasyReferenceEnvironmentPr
       
       {/* Hyper-realistic mountains */}
       <ProceduralMountainTerrain
-        chunks={chunks.slice(0, 25)}
+        chunks={chunks}
         chunkSize={chunkSize}
         realm={realm}
       />


### PR DESCRIPTION
## Summary
- show mountains in fantasy environment
- allow unlimited chunk mountains

## Testing
- `npm run lint` *(fails: React hook rules and unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68405f48a814832ea8b337fd74b9b3ee