### PR TITLE
Fix staff visibility and clean up performance logs

### DIFF
--- a/src/components/ChunkSystem.tsx
+++ b/src/components/ChunkSystem.tsx
@@ -70,8 +70,6 @@ export const ChunkSystem: React.FC<ChunkSystemProps> = React.memo(({
       }
     }
     
-    console.log(`ChunkSystem: Generated ${chunks.length} chunks (max: ${maxChunks}) with render distance ${maxRenderDistance}`);
-    
     return chunks;
   }, [
     Math.floor(playerPosition.x / chunkSize), 

--- a/src/components/GLBTreeSystem.tsx
+++ b/src/components/GLBTreeSystem.tsx
@@ -109,17 +109,13 @@ export const GLBTreeSystem: React.FC<GLBTreeSystemProps> = ({
 }) => {
   const groupRef = useRef();
 
-  console.log('GLBTreeSystem render - Realm:', realm, 'Chunks:', chunks.length);
-
   // Only render for fantasy realm
   if (realm !== 'fantasy') {
-    console.log('GLBTreeSystem: Not fantasy realm, skipping');
     return null;
   }
 
   // Generate tree positions for each chunk
   const treePositions = useMemo(() => {
-    console.log('Generating tree positions for', chunks.length, 'chunks');
     const positions: Array<{
       x: number;
       z: number;
@@ -137,7 +133,6 @@ export const GLBTreeSystem: React.FC<GLBTreeSystemProps> = ({
       
       // Generate fewer trees per chunk to avoid overcrowding
       const treeCount = 1 + Math.floor(seededRandom(seed) * 2); // 1-2 trees per chunk
-      console.log(`Chunk ${chunk.id}: generating ${treeCount} trees at world position (${worldX}, ${worldZ})`);
       
       for (let i = 0; i < treeCount; i++) {
         let attempts = 0;
@@ -189,14 +184,11 @@ export const GLBTreeSystem: React.FC<GLBTreeSystemProps> = ({
         
         if (validPosition && x !== undefined && z !== undefined && y !== undefined && scale !== undefined && rotation !== undefined && modelUrl !== undefined) {
           positions.push({ x, z, y, scale, rotation, modelUrl, chunkId: seed });
-          console.log(`Tree ${i} placed at (${x.toFixed(2)}, ${y.toFixed(2)}, ${z.toFixed(2)}) with scale ${scale.toFixed(2)}`);
         } else {
-          console.warn(`Failed to place tree ${i} in chunk ${chunk.id} after ${maxAttempts} attempts`);
+          // Failed to place tree after max attempts
         }
       }
     });
-    
-    console.log(`Total trees generated: ${positions.length}`);
     return positions;
   }, [chunks, chunkSize]);
 
@@ -217,13 +209,11 @@ export const GLBTreeSystem: React.FC<GLBTreeSystemProps> = ({
   );
 };
 
-// Preload the model for better performance, but handle errors gracefully
-console.log('Attempting to preload GLB tree models...');
+// Preload the model for better performance
 Object.values(TREE_MODELS).forEach((url) => {
   try {
     useGLTF.preload(url);
-    console.log('Preloaded tree model:', url);
-  } catch (error) {
-    console.warn('Failed to preload GLB model:', url, error);
+  } catch {
+    /* ignore preload errors */
   }
 });

--- a/src/components/MapSkillTreeView.tsx
+++ b/src/components/MapSkillTreeView.tsx
@@ -74,7 +74,6 @@ export const MapSkillTreeView: React.FC<MapSkillTreeViewProps> = ({
 
   const handle3DUpgradePurchase = useCallback(() => {
     // Handle 3D upgrade purchase logic here
-    console.log('Purchasing 3D upgrade:', selected3DUpgrade);
     setSelected3DUpgrade(null);
   }, [selected3DUpgrade]);
 

--- a/src/components/WizardStaffWeapon.tsx
+++ b/src/components/WizardStaffWeapon.tsx
@@ -72,7 +72,7 @@ export const WizardStaffWeapon: React.FC<WizardStaffWeaponProps> = ({
 
   return (
     <group ref={staffGroup}>
-      <WizardStaff />
+      <WizardStaff visible />
       {projectiles.map(p => (
         <mesh
           key={p.id}


### PR DESCRIPTION
## Summary
- show the wizard staff by default
- trim heavy runtime logging in ChunkSystem and GLBTreeSystem
- remove debug log from MapSkillTreeView

## Testing
- `npm run lint` *(fails: 76 errors, 34 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6841a6a961a8832eb3f09034bab2690a