### PR TITLE
Add auto combat improvements

### DIFF
--- a/src/components/Enemy.tsx
+++ b/src/components/Enemy.tsx
@@ -1,21 +1,21 @@
 
-import React, { useRef, useEffect } from 'react';
+import React, { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Group, Vector3 } from 'three';
 
 interface EnemyProps {
-  position: [number, number, number];
+  data: import('./EnemySystem').EnemyData;
   playerPosition: Vector3;
   onReachPlayer?: () => void;
 }
 
-export const Enemy: React.FC<EnemyProps> = ({ 
-  position, 
-  playerPosition, 
-  onReachPlayer 
+export const Enemy: React.FC<EnemyProps> = ({
+  data,
+  playerPosition,
+  onReachPlayer
 }) => {
   const groupRef = useRef<Group>(null);
-  const currentPosition = useRef(new Vector3(...position));
+  const currentPosition = useRef(new Vector3(...data.position));
   const speed = 2; // units per second
 
   useFrame((_, delta) => {
@@ -40,28 +40,50 @@ export const Enemy: React.FC<EnemyProps> = ({
     }
   });
 
+  const healthRatio = data.health / data.maxHealth;
+
   return (
-    <group ref={groupRef} position={position} castShadow receiveShadow>
-      {/* Body */}
-      <mesh position={[0, -1, 0]}>
-        <cylinderGeometry args={[0.3, 0.6, 1.5, 8]} />
-        <meshStandardMaterial color="#552222" />
-      </mesh>
+    <group ref={groupRef} position={data.position} castShadow receiveShadow>
+      {data.type === 'demon' ? (
+        <>
+          <mesh position={[0, -1, 0]}>
+            <cylinderGeometry args={[0.3, 0.6, 1.5, 8]} />
+            <meshStandardMaterial color="#552222" />
+          </mesh>
+          <mesh position={[0, 0.5, 0]}>
+            <sphereGeometry args={[0.5, 16, 16]} />
+            <meshStandardMaterial color="#dd3344" />
+          </mesh>
+          <mesh position={[0.35, 0.9, 0]} rotation={[0, 0, Math.PI / 8]}>
+            <coneGeometry args={[0.2, 0.5, 8]} />
+            <meshStandardMaterial color="#ffd700" />
+          </mesh>
+          <mesh position={[-0.35, 0.9, 0]} rotation={[0, 0, -Math.PI / 8]}>
+            <coneGeometry args={[0.2, 0.5, 8]} />
+            <meshStandardMaterial color="#ffd700" />
+          </mesh>
+        </>
+      ) : (
+        <>
+          <mesh position={[0, -1, 0]}>
+            <boxGeometry args={[0.8, 1.6, 0.6]} />
+            <meshStandardMaterial color="green" />
+          </mesh>
+          <mesh position={[0, 0.6, 0]}>
+            <sphereGeometry args={[0.4, 12, 12]} />
+            <meshStandardMaterial color="#88aa66" />
+          </mesh>
+        </>
+      )}
 
-      {/* Head */}
-      <mesh position={[0, 0.5, 0]}>
-        <sphereGeometry args={[0.5, 16, 16]} />
-        <meshStandardMaterial color="#dd3344" />
+      {/* Health bar */}
+      <mesh position={[0, 1.5, 0]}>
+        <boxGeometry args={[1, 0.1, 0.1]} />
+        <meshBasicMaterial color="red" />
       </mesh>
-
-      {/* Horns */}
-      <mesh position={[0.35, 0.9, 0]} rotation={[0, 0, Math.PI / 8]}>
-        <coneGeometry args={[0.2, 0.5, 8]} />
-        <meshStandardMaterial color="#ffd700" />
-      </mesh>
-      <mesh position={[-0.35, 0.9, 0]} rotation={[0, 0, -Math.PI / 8]}>
-        <coneGeometry args={[0.2, 0.5, 8]} />
-        <meshStandardMaterial color="#ffd700" />
+      <mesh position={[-(1 - healthRatio) / 2, 1.5, 0.05]}>
+        <boxGeometry args={[healthRatio, 0.1, 0.05]} />
+        <meshBasicMaterial color="lime" />
       </mesh>
     </group>
   );

--- a/src/components/Fantasy3DScene.tsx
+++ b/src/components/Fantasy3DScene.tsx
@@ -18,7 +18,8 @@ interface Fantasy3DSceneProps {
   chunkSize: number;
   renderDistance: number;
   onEnemyCountChange?: (count: number) => void;
-  onEnemyKilled?: () => void;
+  onEnemyKilled?: (reward: number) => void;
+  weaponStats: { damage: number; fireRate: number; range: number };
 }
 
 export const Fantasy3DScene: React.FC<Fantasy3DSceneProps> = React.memo(({
@@ -29,6 +30,7 @@ export const Fantasy3DScene: React.FC<Fantasy3DSceneProps> = React.memo(({
   renderDistance,
   onEnemyCountChange,
   onEnemyKilled,
+  weaponStats,
   maxUnlockedUpgrade
 }) => {
   const enemySystemRef = useRef<EnemySystemHandle>(null);
@@ -46,9 +48,9 @@ export const Fantasy3DScene: React.FC<Fantasy3DSceneProps> = React.memo(({
   );
 
   const handleEnemyHit = useCallback(
-    (id: string) => {
-      enemySystemRef.current?.damageEnemy(id, 1);
-      if (onEnemyKilled) onEnemyKilled();
+    (id: string, damage: number) => {
+      const result = enemySystemRef.current?.damageEnemy(id, damage);
+      if (result?.killed && onEnemyKilled) onEnemyKilled(result.reward);
     },
     [onEnemyKilled]
   );
@@ -90,7 +92,11 @@ export const Fantasy3DScene: React.FC<Fantasy3DSceneProps> = React.memo(({
       />
 
       {/* Wizard Staff Weapon */}
-      <WizardStaffWeapon enemies={enemies} onEnemyHit={handleEnemyHit} />
+      <WizardStaffWeapon
+        enemies={enemies}
+        weaponStats={weaponStats}
+        onEnemyHit={handleEnemyHit}
+      />
 
       {/* Magic Staff Weapon System - New upgraded weapon system */}
       <MagicStaffWeaponSystem

--- a/src/components/Fantasy3DUpgradeWorld.tsx
+++ b/src/components/Fantasy3DUpgradeWorld.tsx
@@ -15,7 +15,8 @@ interface Fantasy3DUpgradeWorldProps {
   realm?: 'fantasy' | 'scifi';
   onPlayerPositionUpdate?: (position: { x: number; y: number; z: number }) => void;
   onEnemyCountChange?: (count: number) => void;
-  onEnemyKilled?: () => void;
+  onEnemyKilled?: (reward: number) => void;
+  weaponStats: { damage: number; fireRate: number; range: number };
 }
 
 export const Fantasy3DUpgradeWorld: React.FC<Fantasy3DUpgradeWorldProps> = ({
@@ -26,7 +27,8 @@ export const Fantasy3DUpgradeWorld: React.FC<Fantasy3DUpgradeWorldProps> = ({
   realm = 'fantasy',
   onPlayerPositionUpdate,
   onEnemyCountChange,
-  onEnemyKilled
+  onEnemyKilled,
+  weaponStats
 }) => {
   const {
     cameraPosition,
@@ -77,6 +79,7 @@ export const Fantasy3DUpgradeWorld: React.FC<Fantasy3DUpgradeWorldProps> = ({
           renderDistance={RENDER_DISTANCE}
           onEnemyCountChange={onEnemyCountChange}
           onEnemyKilled={onEnemyKilled}
+          weaponStats={weaponStats}
         />
 
         <Fantasy3DUpgradePedestals

--- a/src/components/GameEngine.tsx
+++ b/src/components/GameEngine.tsx
@@ -80,6 +80,7 @@ const GameEngine: React.FC = () => {
   const {
     combatUpgrades,
     weaponUpgrades,
+    weaponStats,
     buyBuilding,
     performConvergence,
     purchaseUpgrade,
@@ -101,6 +102,14 @@ const GameEngine: React.FC = () => {
   const handleEnemyCountChange = useCallback((count: number) => {
     setEnemyCount(count);
   }, []);
+
+  const handleEnemyKilled = useCallback((reward: number) => {
+    setGameState(prev => ({
+      ...prev,
+      mana: prev.mana + reward,
+      enemiesKilled: prev.enemiesKilled + 1
+    }));
+  }, [setGameState]);
 
   const handleJourneyUpdate = useCallback((distance: number) => {
     const currentDistance = currentRealm === 'fantasy' ? stableGameState.fantasyJourneyDistance : stableGameState.scifiJourneyDistance;
@@ -226,6 +235,8 @@ const GameEngine: React.FC = () => {
           onTapEffectComplete={handleTapEffectComplete}
           onPlayerPositionUpdate={handlePlayerPositionUpdate}
           onEnemyCountChange={handleEnemyCountChange}
+          onEnemyKilled={handleEnemyKilled}
+          weaponStats={weaponStats}
         />
 
         {/* Realm Transition Effect */}

--- a/src/components/MapSkillTreeView.tsx
+++ b/src/components/MapSkillTreeView.tsx
@@ -24,7 +24,8 @@ interface MapSkillTreeViewProps {
   onTapEffectComplete?: () => void;
   onPlayerPositionUpdate?: (position: { x: number; y: number; z: number }) => void;
   onEnemyCountChange?: (count: number) => void;
-  onEnemyKilled?: () => void;
+  onEnemyKilled?: (reward: number) => void;
+  weaponStats: { damage: number; fireRate: number; range: number };
 }
 
 export const MapSkillTreeView: React.FC<MapSkillTreeViewProps> = ({
@@ -42,7 +43,8 @@ export const MapSkillTreeView: React.FC<MapSkillTreeViewProps> = ({
   onTapEffectComplete,
   onPlayerPositionUpdate,
   onEnemyCountChange,
-  onEnemyKilled
+  onEnemyKilled,
+  weaponStats
 }) => {
   const [selectedBuilding, setSelectedBuilding] = useState<{
     building: any;
@@ -102,6 +104,7 @@ export const MapSkillTreeView: React.FC<MapSkillTreeViewProps> = ({
           onPlayerPositionUpdate={onPlayerPositionUpdate}
           onEnemyCountChange={onEnemyCountChange}
           onEnemyKilled={onEnemyKilled}
+          weaponStats={weaponStats}
         />
       ) : (
         <Scene3D


### PR DESCRIPTION
## Summary
- scale enemy health and mana rewards based on travel distance
- add enemy health bars and two enemy types
- auto-fire staff weapon using upgrade stats
- award mana on enemy death
- plumb weapon stats through UI to 3D scene

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841cad8b924832e8113fd22e33bc099