### PR TITLE
Improve load time with lazy loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 
-import React from 'react';
+import React, { Suspense } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from '@/components/ui/sonner';
-import Index from './pages/Index';
-import NotFound from './pages/NotFound';
 import { iPhoneFrameMinimal as IPhoneFrameMinimal } from '@/components/iPhoneFrameMinimal';
+
+const Index = React.lazy(() => import('./pages/Index'));
+const NotFound = React.lazy(() => import('./pages/NotFound'));
 
 const queryClient = new QueryClient();
 
@@ -14,10 +15,18 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <Router>
         <IPhoneFrameMinimal>
-          <Routes>
-            <Route path="/" element={<Index />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
+          <Suspense
+            fallback={
+              <div className="flex items-center justify-center h-full text-white">
+                Loading...
+              </div>
+            }
+          >
+            <Routes>
+              <Route path="/" element={<Index />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </Suspense>
         </IPhoneFrameMinimal>
         <Toaster />
       </Router>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,8 +1,20 @@
 
-import GameEngine from '@/components/GameEngine';
+import React, { Suspense } from 'react';
+
+const GameEngine = React.lazy(() => import('@/components/GameEngine'));
 
 const Index = () => {
-  return <GameEngine />;
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center h-full text-white">
+          Loading...
+        </div>
+      }
+    >
+      <GameEngine />
+    </Suspense>
+  );
 };
 
 export default Index;


### PR DESCRIPTION
## Summary
- lazily load heavy pages and components to reduce initial bundle size
- add suspense fallbacks for better UX while loading

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841cd8831f8832eab798684d1dcff3d