### PR TITLE
Adjust upgrade spacing and 3D projectile

### DIFF
--- a/src/components/AutoWeapon.tsx
+++ b/src/components/AutoWeapon.tsx
@@ -129,7 +129,14 @@ export const AutoWeapon: React.FC<AutoWeaponProps> = ({
               zIndex: Math.floor(50 - projectile.z)
             }}
           >
-            <div className="text-xl text-yellow-400 drop-shadow-lg animate-pulse">🏹</div>
+            <div
+              className="w-4 h-4 rounded-full shadow-md"
+              style={{
+                background:
+                  'radial-gradient(circle at 30% 30%, #fff89e, #facc15 60%, #b45309)',
+                border: '1px solid rgba(250, 204, 21, 0.8)'
+              }}
+            />
           </div>
         );
       })}

--- a/src/components/hooks/useFantasy3DUpgradeWorld.tsx
+++ b/src/components/hooks/useFantasy3DUpgradeWorld.tsx
@@ -24,7 +24,8 @@ export const useFantasy3DUpgradeWorld = ({
   // Enhanced infinite world parameters
   const CHUNK_SIZE = 80;
   const RENDER_DISTANCE = 200;
-  const UPGRADE_SPACING = 35;
+  // Increase spacing so mana upgrades appear farther apart
+  const UPGRADE_SPACING = 60;
 
   // Get dynamic upgrades based on player position
   const upgrades = useInfiniteUpgrades({


### PR DESCRIPTION
## Summary
- space out fantasy mana upgrades more within the infinite world
- change the auto weapon projectiles to be spherical and more 3D looking

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841d03de3a8832eaf2518a91ab8526e