### PR TITLE
Adjust health bar direction and upgrade spacing

### DIFF
--- a/src/components/Enemy.tsx
+++ b/src/components/Enemy.tsx
@@ -81,7 +81,7 @@ export const Enemy: React.FC<EnemyProps> = ({
         <boxGeometry args={[1, 0.1, 0.1]} />
         <meshBasicMaterial color="red" />
       </mesh>
-      <mesh position={[-(1 - healthRatio) / 2, 1.5, 0.05]}>
+      <mesh position={[(1 - healthRatio) / 2, 1.5, 0.05]}>
         <boxGeometry args={[healthRatio, 0.1, 0.05]} />
         <meshBasicMaterial color="lime" />
       </mesh>

--- a/src/components/hooks/useFantasy3DUpgradeWorld.tsx
+++ b/src/components/hooks/useFantasy3DUpgradeWorld.tsx
@@ -24,8 +24,8 @@ export const useFantasy3DUpgradeWorld = ({
   // Enhanced infinite world parameters
   const CHUNK_SIZE = 80;
   const RENDER_DISTANCE = 200;
-  // Increase spacing so mana upgrades appear farther apart
-  const UPGRADE_SPACING = 60;
+  // Increase spacing so mana upgrades appear much farther apart
+  const UPGRADE_SPACING = 150;
 
   // Get dynamic upgrades based on player position
   const upgrades = useInfiniteUpgrades({


### PR DESCRIPTION
## Summary
- adjust enemy health bar orientation to drain right-to-left
- place interactable upgrades farther apart for better pacing

## Testing
- `npm run lint` *(fails: various existing eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841d1f9a538832e954259938632dd4f