### PR TITLE
Add wizard staff auto fire and update health bar

### DIFF
--- a/src/components/Enemy.tsx
+++ b/src/components/Enemy.tsx
@@ -81,7 +81,7 @@ export const Enemy: React.FC<EnemyProps> = ({
         <boxGeometry args={[1, 0.1, 0.1]} />
         <meshBasicMaterial color="red" />
       </mesh>
-      <mesh position={[(1 - healthRatio) / 2, 1.5, 0.05]}>
+      <mesh position={[-(1 - healthRatio) / 2, 1.5, 0.05]}>
         <boxGeometry args={[healthRatio, 0.1, 0.05]} />
         <meshBasicMaterial color="lime" />
       </mesh>


### PR DESCRIPTION
## Summary
- make health bar drain right-to-left
- fire projectiles from the wizard staff automatically
- projectiles despawn after a few seconds

## Testing
- `npm run build`
- `npm run lint` *(fails: 79 errors, 37 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6841eb9f2e30832e8648f6630d51ac41