### PR TITLE
Adjust mountain placement and add atmospheric fog

### DIFF
--- a/src/components/CasualFog.tsx
+++ b/src/components/CasualFog.tsx
@@ -1,0 +1,27 @@
+import { useRef, useEffect } from 'react';
+import { useThree, useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+
+/**
+ * Simple fog effect that slowly fades out to reveal the environment.
+ */
+export const CasualFog = () => {
+  const { scene } = useThree();
+  const fogRef = useRef(new THREE.Fog('#2d1b4e', 10, 60));
+
+  useEffect(() => {
+    scene.fog = fogRef.current;
+    return () => {
+      scene.fog = null;
+    };
+  }, [scene]);
+
+  useFrame(() => {
+    const fog = fogRef.current;
+    if (fog.far < 180) {
+      fog.far += 0.5; // gradually increase visibility
+    }
+  });
+
+  return null;
+};

--- a/src/components/Fantasy3DScene.tsx
+++ b/src/components/Fantasy3DScene.tsx
@@ -9,6 +9,7 @@ import { EnemySystem, EnemySystemHandle, EnemyData } from './EnemySystem';
 import { WizardStaffWeapon } from './WizardStaffWeapon';
 import { Enemy } from './Enemy';
 import { useEnemyDamageSystem } from '../hooks/useEnemyDamageSystem';
+import { CasualFog } from './CasualFog';
 
 interface Fantasy3DSceneProps {
   cameraPosition: Vector3;
@@ -87,6 +88,9 @@ export const Fantasy3DScene: React.FC<Fantasy3DSceneProps> = React.memo(({
 
       {/* Background color for fantasy dusk */}
       <color attach="background" args={['#2d1b4e']} />
+
+      {/* Subtle fog that fades as you progress */}
+      <CasualFog />
 
       {/* Ground plane to ensure there's always a visible floor */}
       <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -1, 0]} receiveShadow>

--- a/src/components/InfiniteEnvironmentSystem.tsx
+++ b/src/components/InfiniteEnvironmentSystem.tsx
@@ -19,8 +19,10 @@ const seededRandom = (seed: number) => {
 };
 
 // Check if position is within mountain boundaries (between left and right mountains)
+// Mountains now sit closer to the player path so clamp tree generation tighter
 const isWithinMountainBoundaries = (x: number): boolean => {
-  return Math.abs(x) < 140; // Keep trees within ±140 units to avoid mountain overlap at ±160
+  // Keep trees within ±50 units to avoid overlap with mountains positioned at ±60
+  return Math.abs(x) < 50;
 };
 
 // Check if position is on player path
@@ -129,15 +131,15 @@ export const InfiniteEnvironmentSystem: React.FC<InfiniteEnvironmentSystemProps>
       const z = chunkZ - (i * mountainSpacing);
       const mountainSeed = chunkId * 1000 + i * 73;
       
-      // Left mountains (maximum separation - moved to -160)
-      const leftMountain = createMountain(-160, z, mountainSeed);
+      // Left mountains positioned closer to the path
+      const leftMountain = createMountain(-60, z, mountainSeed);
       if (leftMountain) {
         scene.add(leftMountain);
         mountains.push(leftMountain);
       }
       
-      // Right mountains (maximum separation - moved to 160)
-      const rightMountain = createMountain(160, z, mountainSeed + 500);
+      // Right mountains positioned closer to the path
+      const rightMountain = createMountain(60, z, mountainSeed + 500);
       if (rightMountain) {
         scene.add(rightMountain);
         mountains.push(rightMountain);
@@ -169,9 +171,9 @@ export const InfiniteEnvironmentSystem: React.FC<InfiniteEnvironmentSystemProps>
         }
         
         // Additional safety check - ensure trees are not too close to mountain positions
-        const leftMountainDistance = Math.abs(x - (-160));
-        const rightMountainDistance = Math.abs(x - 160);
-        if (leftMountainDistance < 25 || rightMountainDistance < 25) {
+        const leftMountainDistance = Math.abs(x - (-60));
+        const rightMountainDistance = Math.abs(x - 60);
+        if (leftMountainDistance < 20 || rightMountainDistance < 20) {
           attempts++;
           continue;
         }
@@ -207,7 +209,7 @@ export const InfiniteEnvironmentSystem: React.FC<InfiniteEnvironmentSystemProps>
       }
     }
     
-    console.log(`Generated chunk ${chunkId} with ${mountains.length} maximally separated mountains at ±160 units and ${trees.length} trees`);
+    console.log(`Generated chunk ${chunkId} with ${mountains.length} mountains at ±60 units and ${trees.length} trees`);
     
     return {
       id: chunkId,


### PR DESCRIPTION
## Summary
- move infinite environment mountains closer to the path and tighten tree bounds
- add a subtle fog effect that fades out naturally
- integrate the fog into the fantasy scene

## Testing
- `npm run lint` *(fails: cannot satisfy existing lint rules)*

------
https://chatgpt.com/codex/tasks/task_e_68474f5c91cc832e9f2e4c88ed22d5f9