### PR TITLE
Improve environment generation

### DIFF
--- a/src/components/ChunkSystem.tsx
+++ b/src/components/ChunkSystem.tsx
@@ -41,7 +41,7 @@ export const ChunkSystem: React.FC<ChunkSystemProps> = React.memo(({
     
     // FIXED: Increased chunk limit to prevent premature culling
     let chunkCount = 0;
-    const maxChunks = 120; // Increased from 60
+    const maxChunks = 500; // Allow many more chunks for true infinite terrain
     
     // Generate chunks in a larger pattern with overlap for seamless coverage
     for (let x = playerChunkX - chunkRadius - 1; x <= playerChunkX + chunkRadius + 1 && chunkCount < maxChunks; x++) {

--- a/src/components/EnhancedTreeDistribution.tsx
+++ b/src/components/EnhancedTreeDistribution.tsx
@@ -64,7 +64,7 @@ const isInMountainBoundary = (x: number, z: number): boolean => {
 // UPDATED tree positioning with mountain boundary respect
 const isValidTreePosition = (x: number, z: number): boolean => {
   const notInPlayerPath = !isInPlayerPath(x, z);
-  const inValidXRange = Math.abs(x) >= 4.5 && Math.abs(x) <= 4.8; // Tight range between path and mountains
+  const inValidXRange = Math.abs(x) >= 4.5 && Math.abs(x) <= 7; // Wider scatter range
   const notOnSteepSlope = !isOnSteepSlope(x, z);
   const notTooCloseToPlayer = !isTooCloseToPlayerStart(x, z);
   const notInMountainBoundary = !isInMountainBoundary(x, z);
@@ -270,7 +270,7 @@ export const EnhancedTreeDistribution: React.FC<EnhancedTreeDistributionProps> =
           
           // Controlled positioning between path and mountains
           const side = seededRandom(treeSeed + 10) > 0.5 ? 1 : -1;
-          const sideOffset = 4.6 + seededRandom(treeSeed) * 0.2;
+          const sideOffset = 4.5 + seededRandom(treeSeed) * 2.5; // Scatter further from path
           x = side * sideOffset;
           z = worldZ + (seededRandom(treeSeed + 1) - 0.5) * chunkSize * 0.6;
           

--- a/src/components/FantasyPathSystem.tsx
+++ b/src/components/FantasyPathSystem.tsx
@@ -4,7 +4,7 @@ import { useGLTF } from '@react-three/drei';
 import { ChunkData } from './ChunkSystem';
 import * as THREE from 'three';
 
-const FANTASY_PATH_TILE_URL = 'https://raw.githubusercontent.com/jake222colostate/OK/main/fantasy_path_tile.glb';
+const FANTASY_PATH_TILE_URL = '/assets/dusty_foot_path_way_in_grass_garden.glb';
 
 // Fallback path tile component using basic geometry
 const FallbackPathTile: React.FC<{ 


### PR DESCRIPTION
## Summary
- scatter fantasy trees with wider X range
- use dusty path GLB ground tiles
- allow more chunks for infinite terrain
- preload dusty path model
- update fantasy path tile URL

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68484e117988832ea6d4e807174dc180