### PR TITLE
Fix path tile scaling

### DIFF
--- a/src/components/EnhancedInfiniteGroundSystem.tsx
+++ b/src/components/EnhancedInfiniteGroundSystem.tsx
@@ -5,6 +5,10 @@ import { Vector3 } from 'three';
 import * as THREE from 'three';
 import { useGLTF } from '@react-three/drei';
 
+// Dimensions of the GLB path model obtained via bounding box inspection
+const MODEL_WIDTH = 32.9; // X size of dusty_foot_path_way_in_grass_garden.glb
+const MODEL_LENGTH = 41.6; // Z size after laying flat
+
 interface EnhancedInfiniteGroundSystemProps {
   chunks: ChunkData[];
   chunkSize: number;
@@ -90,7 +94,7 @@ export const EnhancedInfiniteGroundSystem: React.FC<EnhancedInfiniteGroundSystem
             key={tile.key}
             position={tile.position}
             rotation={[-Math.PI / 2, 0, 0]}
-            scale={[0.4 * (tile.size / chunkSize), 0.4, 0.4 * (tile.size / chunkSize)]}
+            scale={[tile.size / MODEL_WIDTH, 1, tile.size / MODEL_LENGTH]}
             frustumCulled={false}
             matrixAutoUpdate={true}
             renderOrder={-tile.layer}


### PR DESCRIPTION
## Summary
- scale the fantasy path GLB to match tile size in `EnhancedInfiniteGroundSystem`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68486185af18832ea6af400f16392b28