### PR TITLE
Fix path orientation and clipping

### DIFF
--- a/src/components/EnhancedInfiniteGroundSystem.tsx
+++ b/src/components/EnhancedInfiniteGroundSystem.tsx
@@ -53,7 +53,7 @@ export const EnhancedInfiniteGroundSystem: React.FC<EnhancedInfiniteGroundSystem
     for (let z = startZ; z <= endZ; z += tileSize) {
       // MULTIPLE ground layers for guaranteed coverage
       for (let layer = 0; layer < 3; layer++) {
-        const layerY = -1.8 - (layer * 0.1); // Stacked layers
+        const layerY = -2.0 - (layer * 0.1); // Lowered layers to avoid clipping
         
         // Main ground plane with massive overlap
         tiles.push({
@@ -93,7 +93,7 @@ export const EnhancedInfiniteGroundSystem: React.FC<EnhancedInfiniteGroundSystem
             object={pathModel.clone()}
             key={tile.key}
             position={tile.position}
-            rotation={[-Math.PI / 2, 0, 0]}
+            rotation={[-Math.PI / 2, Math.PI / 2, 0]} // Align path orientation
             scale={[tile.size / MODEL_WIDTH, 1, tile.size / MODEL_LENGTH]}
             frustumCulled={false}
             matrixAutoUpdate={true}

--- a/src/components/EnhancedTreeDistribution.tsx
+++ b/src/components/EnhancedTreeDistribution.tsx
@@ -158,7 +158,7 @@ const GLBTree: React.FC<{
   // FIXED: Ground level positioning
   const adjustedPosition: [number, number, number] = [
     position[0],
-    -1.8 + TREE_Y_OFFSETS[treeType],
+    -1.7 + TREE_Y_OFFSETS[treeType], // Slightly raised to avoid clipping
     position[2]
   ];
 
@@ -283,7 +283,7 @@ export const EnhancedTreeDistribution: React.FC<EnhancedTreeDistributionProps> =
           treeType = getTreeType(treeSeed + 2);
           scale = getTreeScale(treeType, treeSeed + 3);
           rotation = seededRandom(treeSeed + 4) * Math.PI * 2;
-          finalY = -1.8; // Fixed ground level positioning
+          finalY = -1.7; // Slightly above ground to prevent clipping
           
           validPosition = allPositions.every(pos => {
             const distance = Math.sqrt(

--- a/src/components/InfiniteUpgradeSystem.tsx
+++ b/src/components/InfiniteUpgradeSystem.tsx
@@ -62,7 +62,7 @@ export const useInfiniteUpgrades = ({
       const offset = 3 + Math.floor(i / 16) * 0.5; // Gradually increase spread
       const x = side * offset;
       const z = -(i * upgradeSpacing);
-      const y = 0;
+      const y = -1.6; // Position upgrades near ground level
       
       // Scale increases with tier for visual progression
       const baseScale = 1.0 + (i * 0.1);

--- a/src/components/Scene3D.tsx
+++ b/src/components/Scene3D.tsx
@@ -106,9 +106,9 @@ export const Scene3D: React.FC<Scene3DProps> = React.memo(({
             <WizardStaff />
           </PerspectiveCamera>
 
-          <VerticalCameraController 
+          <VerticalCameraController
             camera={cameraRef.current}
-            minY={-5}
+            minY={0}
             maxY={15}
             sensitivity={0.8}
           />


### PR DESCRIPTION
## Summary
- adjust infinite ground path orientation and depth
- raise tree positions slightly and upgrade spawns to prevent clipping
- restrict camera from dipping below the ground

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684864c3779c832e8d9ab720bb9aa09f