### PR TITLE
Fix ground rotation

### DIFF
--- a/src/components/EnhancedInfiniteGroundSystem.tsx
+++ b/src/components/EnhancedInfiniteGroundSystem.tsx
@@ -88,9 +88,9 @@ export const EnhancedInfiniteGroundSystem: React.FC<EnhancedInfiniteGroundSystem
           <primitive
             object={pathModel.clone()}
             key={tile.key}
-            position={[tile.position[0], tile.position[1] - 1, tile.position[2]]}
-            rotation={[-Math.PI / 2 + Math.PI / 4, 0, 0]}
-            scale={[0.8 * (tile.size / chunkSize), 0.8, 0.8 * (tile.size / chunkSize)]}
+            position={tile.position}
+            rotation={[-Math.PI / 2, 0, 0]}
+            scale={[0.4 * (tile.size / chunkSize), 0.4, 0.4 * (tile.size / chunkSize)]}
             frustumCulled={false}
             matrixAutoUpdate={true}
             renderOrder={-tile.layer}

--- a/src/components/FantasyPathSystem.tsx
+++ b/src/components/FantasyPathSystem.tsx
@@ -76,9 +76,9 @@ const FantasyPathTile: React.FC<{
       <group position={position}>
         <primitive
           object={clonedScene}
-          scale={[widthScale * 2, 2, lengthScale * 2]}
-          rotation={[-Math.PI / 2 + Math.PI / 4, 0, 0]} // Tilted 45 degrees
-          position={[0, -1, 0]} // Slightly lower to avoid clipping
+          scale={[widthScale, 1, lengthScale]}
+          rotation={[-Math.PI / 2, 0, 0]} // Lay flat along the ground
+          position={[0, 0, 0]} // Centered and at ground level
           receiveShadow
           castShadow
         />


### PR DESCRIPTION
## Summary
- keep path tiles flat so the ground isn't slanted

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68486e03e084832ea9b68230dd0d7727