### PR TITLE
Fix ground path scaling

### DIFF
--- a/src/components/EnhancedInfiniteGroundSystem.tsx
+++ b/src/components/EnhancedInfiniteGroundSystem.tsx
@@ -5,6 +5,10 @@ import { Vector3 } from 'three';
 import * as THREE from 'three';
 import { useGLTF } from '@react-three/drei';
 
+// Dimensions of dusty_foot_path_way_in_grass_garden.glb determined from bounding box
+const MODEL_WIDTH = 32.905; // approx X size
+const MODEL_LENGTH = 41.633; // approx Z size when laid flat
+
 interface EnhancedInfiniteGroundSystemProps {
   chunks: ChunkData[];
   chunkSize: number;
@@ -88,9 +92,9 @@ export const EnhancedInfiniteGroundSystem: React.FC<EnhancedInfiniteGroundSystem
           <primitive
             object={pathModel.clone()}
             key={tile.key}
-            position={tile.position}
+            position={[tile.position[0], tile.position[1] + 0.05, tile.position[2]]}
             rotation={[-Math.PI / 2, 0, 0]}
-            scale={[0.4 * (tile.size / chunkSize), 0.4, 0.4 * (tile.size / chunkSize)]}
+            scale={[tile.size / MODEL_WIDTH, 1, tile.size / MODEL_LENGTH]}
             frustumCulled={false}
             matrixAutoUpdate={true}
             renderOrder={-tile.layer}

--- a/src/components/EnhancedTreeDistribution.tsx
+++ b/src/components/EnhancedTreeDistribution.tsx
@@ -44,7 +44,7 @@ const isOnSteepSlope = (x: number, z: number): boolean => {
 
 // Check if position is in the main player path corridor
 const isInPlayerPath = (x: number, z: number): boolean => {
-  const pathWidth = 4; // Reduced from 6 to allow trees closer to path
+  const pathWidth = 10; // Wider buffer to avoid trees clipping through path
   return Math.abs(x) < pathWidth;
 };
 


### PR DESCRIPTION
## Summary
- scale dusty path model using measured dimensions
- offset path slightly above ground
- widen path exclusion zone for trees

## Testing
- `npm run lint`
- `npm run build` *(fails: Bus error)*

------
https://chatgpt.com/codex/tasks/task_e_68486f495d14832ea504a936dd20607a