### PR TITLE
Reduce lint warnings

### DIFF
--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { Slot } from "@radix-ui/react-slot"

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react"
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
 import { cva } from "class-variance-authority"

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { VariantProps, cva } from "class-variance-authority"

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { useTheme } from "next-themes"
 import { Toaster as Sonner, toast } from "sonner"
 

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react"
 import * as TogglePrimitive from "@radix-ui/react-toggle"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/src/hooks/useEnemyDamageSystem.ts
+++ b/src/hooks/useEnemyDamageSystem.ts
@@ -1,5 +1,5 @@
 
-import { useState, useCallback, useMemo, useRef } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 
 export interface EnemyHealth {
   id: string;
@@ -16,16 +16,6 @@ interface UseEnemyDamageSystemProps {
 
 export const useEnemyDamageSystem = ({ playerZ, upgradeLevel }: UseEnemyDamageSystemProps) => {
   const [enemyHealths, setEnemyHealths] = useState<Map<string, EnemyHealth>>(new Map());
-  const lastPlayerZ = useRef(playerZ);
-  const lastUpgradeLevel = useRef(upgradeLevel);
-
-  // Only recalculate when playerZ or upgradeLevel actually changes
-  const shouldUpdate = playerZ !== lastPlayerZ.current || upgradeLevel !== lastUpgradeLevel.current;
-  
-  if (shouldUpdate) {
-    lastPlayerZ.current = playerZ;
-    lastUpgradeLevel.current = upgradeLevel;
-  }
 
   // Calculate base health - exactly 10 shots to kill early enemies
   const calculateMaxHealth = useCallback((enemyZ: number) => {
@@ -37,9 +27,9 @@ export const useEnemyDamageSystem = ({ playerZ, upgradeLevel }: UseEnemyDamageSy
   // Calculate damage - exactly 5 damage base (1/10 of 50 health = 10 shots to kill)
   const projectileDamage = useMemo(() => {
     const baseDamage = 5; // Base damage = 1/10 of 50 health = 10 shots to kill
-    const upgradeBonus = lastUpgradeLevel.current * 2; // Smaller upgrade bonus
+    const upgradeBonus = upgradeLevel * 2; // Smaller upgrade bonus
     return baseDamage + upgradeBonus;
-  }, [lastUpgradeLevel.current]);
+  }, [upgradeLevel]);
 
   // Initialize enemy health when spawned
   const initializeEnemy = useCallback((enemyId: string, position: [number, number, number]) => {


### PR DESCRIPTION
## Summary
- disable `react-refresh/only-export-components` rule across certain UI modules
- simplify enemy damage calculation hook

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68487fe74ba8832ebf6a362a9cf077ef