### PR TITLE
Fix enemy model loading

### DIFF
--- a/src/components/BatMinion.tsx
+++ b/src/components/BatMinion.tsx
@@ -2,6 +2,7 @@
 import React, { useRef, useEffect, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { useGLTF } from '@react-three/drei';
+import { assetPath } from '../lib/assetPath';
 import { Group, Vector3, Mesh } from 'three';
 import { EnemyHealthBar } from './EnemyHealthBar';
 import { EnemyHealth } from '../hooks/useEnemyDamageSystem';
@@ -37,7 +38,7 @@ export const BatMinion: React.FC<BatMinionProps> = ({
   const [modelLoaded, setModelLoaded] = useState(false);
 
   // Load vampire bat model - useGLTF throws errors, doesn't return them
-  const { scene: batScene } = useGLTF('/assets/vampire-bat/source/bat.glb');
+  const { scene: batScene } = useGLTF(assetPath('assets/vampire-bat/source/bat.glb'));
 
   useEffect(() => {
     console.log(`BatMinion ${enemyId}: Attempting to load model`);
@@ -242,4 +243,4 @@ export const BatMinion: React.FC<BatMinionProps> = ({
 };
 
 // Preload vampire bat model
-useGLTF.preload('/assets/vampire-bat/source/bat.glb');
+useGLTF.preload(assetPath('assets/vampire-bat/source/bat.glb'));

--- a/src/components/Enemy.tsx
+++ b/src/components/Enemy.tsx
@@ -2,6 +2,7 @@
 import React, { useRef, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { useGLTF } from '@react-three/drei';
+import { assetPath } from '../lib/assetPath';
 import { Group, Vector3, Mesh } from 'three';
 import { EnemyHealthBar } from './EnemyHealthBar';
 import { EnemyHealth } from '../hooks/useEnemyDamageSystem';
@@ -34,9 +35,9 @@ export const Enemy: React.FC<EnemyProps> = ({
   const isFullyFaded = useRef(false);
 
   // Load the correct model based on enemy type
-  const modelPath = enemyType === 'vampire_bat' 
-    ? '/assets/vampire-bat/source/bat.glb' 
-    : '/assets/monster_rig.glb';
+  const modelPath = enemyType === 'vampire_bat'
+    ? assetPath('assets/vampire-bat/source/bat.glb')
+    : assetPath('assets/monster_rig.glb');
     
   console.log(`Enemy ${enemyId}: Loading model from path: ${modelPath} for type: ${enemyType}`);
   const { scene: enemyScene } = useGLTF(modelPath);
@@ -195,5 +196,5 @@ export const Enemy: React.FC<EnemyProps> = ({
 };
 
 // Preload both models
-useGLTF.preload('/assets/vampire-bat/source/bat.glb');
-useGLTF.preload('/assets/monster_rig.glb');
+useGLTF.preload(assetPath('assets/vampire-bat/source/bat.glb'));
+useGLTF.preload(assetPath('assets/monster_rig.glb'));

--- a/src/components/Leech.tsx
+++ b/src/components/Leech.tsx
@@ -2,6 +2,7 @@
 import React, { useRef, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { useGLTF } from '@react-three/drei';
+import { assetPath } from '../lib/assetPath';
 import { Group, Vector3, Mesh } from 'three';
 import { EnemyHealthBar } from './EnemyHealthBar';
 import { EnemyHealth } from '../hooks/useEnemyDamageSystem';
@@ -33,7 +34,7 @@ export const Leech: React.FC<LeechProps> = ({
 
   // Use the vampire bat model as a placeholder since leech.glb doesn't exist
   // This will be rendered differently with materials and scaling
-  const { scene: leechScene } = useGLTF('/assets/vampire-bat/source/bat.glb');
+  const { scene: leechScene } = useGLTF(assetPath('assets/vampire-bat/source/bat.glb'));
 
   useEffect(() => {
     if (leechScene && modelRef.current) {
@@ -136,4 +137,4 @@ export const Leech: React.FC<LeechProps> = ({
 };
 
 // Preload the vampire bat model that we're using as a substitute
-useGLTF.preload('/assets/vampire-bat/source/bat.glb');
+useGLTF.preload(assetPath('assets/vampire-bat/source/bat.glb'));

--- a/src/components/Monster.tsx
+++ b/src/components/Monster.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { useGLTF } from '@react-three/drei';
+import { assetPath } from '../lib/assetPath';
 import { Group, Vector3, Mesh } from 'three';
 import { EnemyHealthBar } from './EnemyHealthBar';
 import { EnemyHealth } from '../hooks/useEnemyDamageSystem';
@@ -30,7 +31,7 @@ export const Monster: React.FC<MonsterProps> = ({
   const fadeOutStarted = useRef(false);
   const isFullyFaded = useRef(false);
 
-  const { scene: monsterScene } = useGLTF('/assets/monster_rig.glb');
+  const { scene: monsterScene } = useGLTF(assetPath('assets/monster_rig.glb'));
 
   useEffect(() => {
     if (monsterScene && modelRef.current) {
@@ -119,4 +120,4 @@ export const Monster: React.FC<MonsterProps> = ({
   );
 };
 
-useGLTF.preload('/assets/monster_rig.glb');
+useGLTF.preload(assetPath('assets/monster_rig.glb'));

--- a/src/lib/assetPath.ts
+++ b/src/lib/assetPath.ts
@@ -1,0 +1,6 @@
+export function assetPath(path: string): string {
+  const base = import.meta.env.BASE_URL || '/';
+  const normalizedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${normalizedBase}${normalizedPath}`;
+}


### PR DESCRIPTION
## Summary
- add assetPath utility for proper asset URL handling
- load enemy models relative to `import.meta.env.BASE_URL`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849acc0da70832e90797eb3e7e00c84