### PR TITLE
Add Leech enemy model and spawn

### DIFF
--- a/src/components/Fantasy3DScene.tsx
+++ b/src/components/Fantasy3DScene.tsx
@@ -1,5 +1,5 @@
 
-import React, { Suspense, useRef, useMemo, useCallback } from 'react';
+import React, { Suspense, useRef, useMemo, useCallback, useState } from 'react';
 import { Vector3 } from 'three';
 import { ContactShadows } from '@react-three/drei';
 import { Enhanced360Controller } from './Enhanced360Controller';
@@ -7,6 +7,7 @@ import { ChunkSystem, ChunkData } from './ChunkSystem';
 import { OptimizedFantasyEnvironment } from './OptimizedFantasyEnvironment';
 import { CasualFog } from './CasualFog';
 import { Sun } from './Sun';
+import { LeechEnemy } from './LeechEnemy';
 
 interface Fantasy3DSceneProps {
   cameraPosition: Vector3;
@@ -32,9 +33,13 @@ export const Fantasy3DScene: React.FC<Fantasy3DSceneProps> = React.memo(({
   maxUnlockedUpgrade
 }) => {
   // Notify that there are no enemies
+  const [enemyAlive, setEnemyAlive] = useState(true);
+
+  const spawnPosition = useMemo(() => new Vector3(0, 0, cameraPosition.z - 60), [cameraPosition.z]);
+
   React.useEffect(() => {
-    if (onEnemyCountChange) onEnemyCountChange(0);
-  }, [onEnemyCountChange]);
+    if (onEnemyCountChange) onEnemyCountChange(enemyAlive ? 1 : 0);
+  }, [enemyAlive, onEnemyCountChange]);
 
   return (
     <Suspense fallback={null}>
@@ -59,6 +64,17 @@ export const Fantasy3DScene: React.FC<Fantasy3DSceneProps> = React.memo(({
       {/* Basic ambient light plus warm sun */}
       <ambientLight intensity={0.6} />
       <Sun position={[10, 20, 5]} />
+
+      {enemyAlive && (
+        <LeechEnemy
+          playerPosition={cameraPosition}
+          startPosition={spawnPosition}
+          onReachPlayer={() => {
+            setEnemyAlive(false);
+            onEnemyKilled && onEnemyKilled();
+          }}
+        />
+      )}
 
       {/* Optimized chunk system with performance limits */}
       <ChunkSystem

--- a/src/components/LeechEnemy.tsx
+++ b/src/components/LeechEnemy.tsx
@@ -1,0 +1,48 @@
+import React, { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { useGLTF } from '@react-three/drei';
+import { Vector3, Group } from 'three';
+import { assetPath } from '../lib/assetPath';
+
+interface LeechEnemyProps {
+  playerPosition: Vector3;
+  startPosition: Vector3;
+  onReachPlayer?: () => void;
+  visible?: boolean;
+}
+
+export const LeechEnemy: React.FC<LeechEnemyProps> = ({
+  playerPosition,
+  startPosition,
+  onReachPlayer,
+  visible = true
+}) => {
+  const groupRef = useRef<Group>(null);
+  const { scene } = useGLTF(assetPath('assets/leech.glb'));
+  const speed = 0.1;
+
+  useFrame(() => {
+    if (!groupRef.current || !visible) return;
+    const dir = new Vector3();
+    dir.subVectors(playerPosition, groupRef.current.position);
+    const distance = dir.length();
+    if (distance < 1) {
+      onReachPlayer && onReachPlayer();
+      return;
+    }
+    dir.normalize();
+    groupRef.current.position.addScaledVector(dir, speed);
+  });
+
+  return (
+    <primitive
+      ref={groupRef}
+      object={scene.clone()}
+      scale={0.6}
+      position={startPosition.toArray() as [number, number, number]}
+      visible={visible}
+    />
+  );
+};
+
+useGLTF.preload(assetPath('assets/leech.glb'));


### PR DESCRIPTION
## Summary
- add `LeechEnemy` component that loads `leech.glb` and moves towards the player
- spawn the leech enemy in `Fantasy3DScene` far ahead of the player

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b695acb4832ebc16afed8fe4be45