### PR TITLE
Fix mountain rendering and update enemy health bar

### DIFF
--- a/src/components/LeechEnemy.tsx
+++ b/src/components/LeechEnemy.tsx
@@ -58,7 +58,12 @@ export const LeechEnemy: React.FC<LeechEnemyProps> = ({
         distanceFactor={8}
       >
         <div className="w-16">
-          <Progress value={health} />
+          <Progress
+            value={health}
+            direction="rtl"
+            indicatorClassName={health < 100 ? 'bg-red-600' : 'bg-green-500'}
+            className="h-2"
+          />
         </div>
       </Html>
     </group>

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -3,10 +3,16 @@ import * as ProgressPrimitive from "@radix-ui/react-progress"
 
 import { cn } from "@/lib/utils"
 
+interface ProgressProps
+  extends React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> {
+  direction?: "ltr" | "rtl"
+  indicatorClassName?: string
+}
+
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+  ProgressProps
+>(({ className, value, direction = "ltr", indicatorClassName, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
@@ -16,8 +22,13 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      className={cn("h-full w-full flex-1 transition-all", indicatorClassName)}
+      style={{
+        transform:
+          direction === "rtl"
+            ? `translateX(${100 - (value || 0)}%)`
+            : `translateX(-${100 - (value || 0)}%)`
+      }}
     />
   </ProgressPrimitive.Root>
 ))


### PR DESCRIPTION
## Summary
- optimize mountain cloning and preload to prevent blinking
- add directional progress bar customization
- use new progress bar settings for enemy health

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849d0f3fa74832e88091d20838093d3