### PR TITLE
Fix sword visibility and adjust mountain spawning

### DIFF
--- a/src/components/CasualFog.tsx
+++ b/src/components/CasualFog.tsx
@@ -7,7 +7,8 @@ import * as THREE from 'three';
  */
 export const CasualFog = () => {
   const { scene } = useThree();
-  const fogRef = useRef(new THREE.Fog('#2d1b4e', 10, 60));
+  // Denser starting fog to hide far objects until they load
+  const fogRef = useRef(new THREE.Fog('#2d1b4e', 5, 50));
 
   useEffect(() => {
     scene.fog = fogRef.current;
@@ -18,8 +19,8 @@ export const CasualFog = () => {
 
   useFrame(() => {
     const fog = fogRef.current;
-    if (fog.far < 180) {
-      fog.far += 0.5; // gradually increase visibility
+    if (fog.far < 250) {
+      fog.far += 0.7; // gradually increase visibility over time
     }
   });
 

--- a/src/components/InfiniteEnvironmentSystem.tsx
+++ b/src/components/InfiniteEnvironmentSystem.tsx
@@ -64,8 +64,9 @@ export const InfiniteEnvironmentSystem: React.FC<InfiniteEnvironmentSystemProps>
   
   // Tune chunk and render distances for better performance
   const CHUNK_SIZE = 25;
-  const RENDER_DISTANCE = 100; // smaller render distance to reduce draw calls
-  const CLEANUP_DISTANCE = 150; // cleanup sooner to free resources
+  // Increase render distance so mountains spawn further away
+  const RENDER_DISTANCE = 150;
+  const CLEANUP_DISTANCE = 200;
   const UPDATE_INTERVAL = 100;
 
   // Create a mountain at specified position - LOWERED into ground

--- a/src/components/SwordWeaponSystem.tsx
+++ b/src/components/SwordWeaponSystem.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { useThree, useFrame } from '@react-three/fiber';
 import { useGLTF } from '@react-three/drei';
+import { useGLTFWithCors } from '../lib/useGLTFWithCors';
 import * as THREE from 'three';
 import { assetPath } from '../lib/assetPath';
 
@@ -17,7 +18,18 @@ export const SwordWeaponSystem: React.FC<SwordWeaponSystemProps> = ({
 }) => {
   const { camera } = useThree();
   const groupRef = useRef<THREE.Group>(null);
-  const { scene } = useGLTF(assetPath('assets/sword_uitlbiaga_mid.glb'));
+  // Load the sword model with CORS-friendly loader
+  const { scene } = useGLTFWithCors(assetPath('assets/sword_uitlbiaga_mid.glb'));
+
+  // Ensure the model casts and receives shadows
+  useEffect(() => {
+    scene.traverse((child) => {
+      if ((child as THREE.Mesh).isMesh) {
+        child.castShadow = true;
+        child.receiveShadow = true;
+      }
+    });
+  }, [scene]);
   const swingRef = useRef(false);
   const hitRef = useRef(false);
   const swingProgress = useRef(0);
@@ -82,7 +94,7 @@ export const SwordWeaponSystem: React.FC<SwordWeaponSystemProps> = ({
 
   return (
     <group ref={groupRef}>
-      <primitive object={scene.clone()} scale={[0.6, 0.6, 0.6]} />
+      <primitive object={scene.clone()} scale={[1, 1, 1]} />
     </group>
   );
 };


### PR DESCRIPTION
## Summary
- load `sword_uitlbiaga_mid.glb` with CORS-friendly loader and ensure sword model casts shadows
- enlarge sword scale for better visibility
- start fog denser and extend maximum distance to hide mountain spawning
- generate environment chunks further out to reduce mountain pop-in

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849d850967c832e98b121b925a1ecc5