### PR TITLE
Fix missing sword asset

### DIFF
--- a/src/components/SwordWeaponSystem.tsx
+++ b/src/components/SwordWeaponSystem.tsx
@@ -27,7 +27,7 @@ export const SwordWeaponSystem: React.FC<SwordWeaponSystemProps> = ({
   let loadError = false;
   
   try {
-    gltfResult = useGLTF('/swordofkasdd.glb');
+    gltfResult = useGLTF('/assets/swordofkasdd.glb');
   } catch (error) {
     console.log('SwordWeaponSystem: Failed to load sword model:', error);
     loadError = true;
@@ -180,4 +180,4 @@ export const SwordWeaponSystem: React.FC<SwordWeaponSystemProps> = ({
   );
 };
 
-useGLTF.preload('/swordofkasdd.glb');
+useGLTF.preload('/assets/swordofkasdd.glb');


### PR DESCRIPTION
## Summary
- load sword model from `public/assets` so it appears on start

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849df856330832eb122a698db5982db