### PR TITLE
Implement enemy kill rewards and cross-world upgrades

### DIFF
--- a/src/components/CrossRealmUpgradeSystem.tsx
+++ b/src/components/CrossRealmUpgradeSystem.tsx
@@ -18,6 +18,7 @@ export interface CrossRealmUpgrade {
     range?: number;
     manaPerSecond?: number;
     energyPerSecond?: number;
+    manaPerKill?: number;
   };
   unlockRequirement?: {
     otherRealm: 'fantasy' | 'scifi';
@@ -187,6 +188,9 @@ export const CrossRealmUpgradeSystem: React.FC<CrossRealmUpgradeSystemProps> = (
                     )}
                     {upgrade.effect.energyPerSecond && (
                       <div>Energy/sec: +{upgrade.effect.energyPerSecond * (upgrade.level + 1)}</div>
+                    )}
+                    {upgrade.effect.manaPerKill && (
+                      <div>Mana/kill: +{upgrade.effect.manaPerKill * (upgrade.level + 1)}</div>
                     )}
                   </div>
                 )}

--- a/src/components/GameEngine.tsx
+++ b/src/components/GameEngine.tsx
@@ -111,6 +111,14 @@ const GameEngine: React.FC = () => {
     setEnemyCount(count);
   }, []);
 
+  const handleEnemyKilled = useCallback(() => {
+    setGameState(prev => ({
+      ...prev,
+      mana: prev.mana + prev.manaPerKill,
+      enemiesKilled: prev.enemiesKilled + 1,
+    }));
+  }, [setGameState]);
+
   const handleJourneyUpdate = useCallback((distance: number) => {
     const currentDistance = currentRealm === 'fantasy' ? stableGameState.fantasyJourneyDistance : stableGameState.scifiJourneyDistance;
     
@@ -270,6 +278,7 @@ const GameEngine: React.FC = () => {
           onTapEffectComplete={handleTapEffectComplete}
           onPlayerPositionUpdate={handlePlayerPositionUpdate}
           onEnemyCountChange={handleEnemyCountChange}
+          onEnemyKilled={handleEnemyKilled}
           weaponDamage={weaponStats.damage}
         />
 

--- a/src/components/GameLoopManager.tsx
+++ b/src/components/GameLoopManager.tsx
@@ -53,6 +53,7 @@ export const useGameLoopManager = ({
   useEffect(() => {
     let manaRate = 0;
     let energyRate = 0;
+    let manaPerKill = 5;
 
     // Base production from buildings
     fantasyBuildings.forEach(building => {
@@ -75,6 +76,9 @@ export const useGameLoopManager = ({
         }
         if (upgrade.effect.energyPerSecond && upgrade.realm === 'scifi') {
           energyRate += upgrade.effect.energyPerSecond * upgrade.level;
+        }
+        if (upgrade.effect.manaPerKill) {
+          manaPerKill += upgrade.effect.manaPerKill * upgrade.level;
         }
       }
     });
@@ -104,6 +108,7 @@ export const useGameLoopManager = ({
       ...prev,
       manaPerSecond: manaRate * fantasyBonus * globalMultiplier,
       energyPerSecond: energyRate * scifiBonus * globalMultiplier,
+      manaPerKill,
     }));
   }, [stableFantasyBuildings, stableScifiBuildings, purchasedUpgradesCount, buffSystem, crossRealmUpgradesWithLevels, setGameState]);
 

--- a/src/components/GameStateManager.tsx
+++ b/src/components/GameStateManager.tsx
@@ -23,6 +23,7 @@ export interface GameState {
   enemiesKilled: number;
   autoManaLevel: number;
   autoManaRate: number;
+  manaPerKill: number;
 }
 
 export interface Building {
@@ -47,6 +48,8 @@ export const scifiBuildings: Building[] = [
   { id: 'reactor', name: 'Fusion Reactor', cost: 150, production: 10, costMultiplier: 1.2, description: 'Advanced nuclear fusion technology', icon: '⚡' },
   { id: 'station', name: 'Space Station', cost: 1500, production: 64, costMultiplier: 1.25, description: 'Orbital platforms generating massive energy', icon: '🛰️' },
   { id: 'megastructure', name: 'Dyson Sphere', cost: 20000, production: 430, costMultiplier: 1.3, description: 'Planet-scale energy harvesting systems', icon: '🌌' },
+  { id: 'orbital_array', name: 'Orbital Array', cost: 150000, production: 1200, costMultiplier: 1.35, description: 'Rings of satellites beaming power', icon: '📡' },
+  { id: 'singularity_core', name: 'Singularity Core', cost: 1000000, production: 8000, costMultiplier: 1.4, description: 'Harnesses miniature black holes', icon: '🕳️' },
 ];
 
 const defaultGameState: GameState = {
@@ -69,6 +72,7 @@ const defaultGameState: GameState = {
   enemiesKilled: 0,
   autoManaLevel: 0,
   autoManaRate: 0,
+  manaPerKill: 5,
 };
 
 export const useGameStateManager = () => {
@@ -89,6 +93,7 @@ export const useGameStateManager = () => {
         enemiesKilled: parsedState.enemiesKilled || 0,
         autoManaLevel: parsedState.autoManaLevel || 0,
         autoManaRate: parsedState.autoManaRate || 0,
+        manaPerKill: parsedState.manaPerKill || 5,
       };
     }
     return defaultGameState;

--- a/src/components/InfiniteUpgradeSystem.tsx
+++ b/src/components/InfiniteUpgradeSystem.tsx
@@ -56,6 +56,9 @@ export const useInfiniteUpgrades = ({
       const tierMultiplier = Math.pow(10, tier); // Each tier is 10x more expensive
       const costMultiplier = Math.pow(2, i); // Base exponential growth
       const manaMultiplier = Math.pow(2, i);
+
+      const isSpecial = (i + 1) % 10 === 0;
+      const specialMultiplier = isSpecial ? 5 : 1;
       
       // Position calculation - alternating sides with increasing distance
       const side = i % 2 === 0 ? -1 : 1;
@@ -76,11 +79,11 @@ export const useInfiniteUpgrades = ({
       upgrades.push({
         id: i + 1,
         name: finalName,
-        baseCost: 50,
-        baseManaPerSecond: 10,
-        cost: Math.floor(50 * costMultiplier * tierMultiplier),
-        manaPerSecond: Math.floor(10 * manaMultiplier * tierMultiplier),
-        unlocked: i <= maxUnlockedUpgrade,
+        baseCost: 50 * specialMultiplier,
+        baseManaPerSecond: 10 * specialMultiplier,
+        cost: Math.floor(50 * costMultiplier * tierMultiplier * specialMultiplier),
+        manaPerSecond: Math.floor(10 * manaMultiplier * tierMultiplier * specialMultiplier),
+        unlocked: i <= maxUnlockedUpgrade + 1,
         modelUrl: template.modelUrl,
         position: [x, y, z] as [number, number, number],
         scale: finalScale,

--- a/src/components/UIStateManager.tsx
+++ b/src/components/UIStateManager.tsx
@@ -12,6 +12,7 @@ interface GameState {
   convergenceCount: number;
   fantasyBuildings: { [key: string]: number };
   scifiBuildings: { [key: string]: number };
+  manaPerKill: number;
 }
 
 interface UseUIStateManagerProps {

--- a/src/components/UpgradeManagers.tsx
+++ b/src/components/UpgradeManagers.tsx
@@ -220,6 +220,7 @@ export const useUpgradeManagers = ({
         scifiJourneyDistance: gameState.scifiJourneyDistance,
         autoManaLevel: gameState.autoManaLevel,
         autoManaRate: gameState.autoManaRate,
+        manaPerKill: gameState.manaPerKill,
       });
     }
   }, [gameState, setGameState]);

--- a/src/components/hooks/useFantasy3DUpgradeWorld.tsx
+++ b/src/components/hooks/useFantasy3DUpgradeWorld.tsx
@@ -73,7 +73,7 @@ export const useFantasy3DUpgradeWorld = ({
     if (currentManaRef.current >= upgrade.cost) {
       currentManaRef.current -= upgrade.cost;
       totalManaPerSecondRef.current += upgrade.manaPerSecond;
-      setMaxUnlockedUpgrade(prev => Math.max(prev, upgrade.id - 1));
+      setMaxUnlockedUpgrade(prev => Math.max(prev, upgrade.id));
       setSelectedUpgrade(null);
       console.log(`Unlocked ${upgrade.name}! +${upgrade.manaPerSecond} mana/sec`);
     } else {

--- a/src/data/CrossRealmUpgrades.ts
+++ b/src/data/CrossRealmUpgrades.ts
@@ -59,6 +59,21 @@ export const crossRealmUpgrades: CrossRealmUpgrade[] = [
       journeyDistance: 500
     }
   },
+  {
+    id: 'fantasy_essence_leech',
+    name: 'Essence Leech',
+    description: 'Steal essence to gain mana per kill',
+    icon: '🩸',
+    realm: 'fantasy',
+    level: 0,
+    maxLevel: 5,
+    baseCost: 200,
+    effect: { manaPerKill: 2 },
+    unlockRequirement: {
+      otherRealm: 'scifi',
+      journeyDistance: 300
+    }
+  },
 
   // Sci-Fi Realm Upgrades
   {
@@ -115,6 +130,36 @@ export const crossRealmUpgrades: CrossRealmUpgrade[] = [
     unlockRequirement: {
       otherRealm: 'fantasy',
       journeyDistance: 500
+    }
+  },
+  {
+    id: 'scifi_mana_siphon',
+    name: 'Mana Siphon',
+    description: 'Harvest energy from defeated foes',
+    icon: '🔋',
+    realm: 'scifi',
+    level: 0,
+    maxLevel: 5,
+    baseCost: 200,
+    effect: { manaPerKill: 3 },
+    unlockRequirement: {
+      otherRealm: 'fantasy',
+      journeyDistance: 300
+    }
+  },
+  {
+    id: 'scifi_gravity_well',
+    name: 'Gravity Well',
+    description: 'Enhances energy generation with gravity fields',
+    icon: '🌀',
+    realm: 'scifi',
+    level: 0,
+    maxLevel: 8,
+    baseCost: 250,
+    effect: { energyPerSecond: 3 },
+    unlockRequirement: {
+      otherRealm: 'fantasy',
+      journeyDistance: 600
     }
   }
 ];


### PR DESCRIPTION
## Summary
- allow sequential fantasy upgrades with special crystals every 10 levels
- reward mana on enemy kills using new `manaPerKill` stat
- add new sci‑fi buildings and cross-realm upgrades
- compute `manaPerKill` from upgrades during game loop
- display mana per kill in upgrade modal

## Testing
- `npm run build`
- `npm run lint` *(shows warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6849e906180c832e9acac87e6e752673