### PR TITLE
Add sci-fi cannon defense

### DIFF
--- a/src/components/Scene3D.tsx
+++ b/src/components/Scene3D.tsx
@@ -12,6 +12,7 @@ import { Sun } from './Sun';
 import { enhancedHybridUpgrades } from '../data/EnhancedHybridUpgrades';
 import { Vector3 } from 'three';
 import { ImprovedFantasyLighting } from './ImprovedFantasyLighting';
+import { ScifiDefenseSystem } from './scifi/ScifiDefenseSystem';
 
 interface Scene3DProps {
   realm: 'fantasy' | 'scifi';
@@ -118,6 +119,7 @@ export const Scene3D: React.FC<Scene3DProps> = React.memo(({
           <ImprovedFantasyLighting />
 
           <FloatingIsland realm={realm} />
+          {realm === 'scifi' && <ScifiDefenseSystem />}
 
           {/* Fantasy environment with polygon mountains removed and fixed tree positioning */}
           {realm === 'fantasy' && (

--- a/src/components/scifi/Asteroid.tsx
+++ b/src/components/scifi/Asteroid.tsx
@@ -1,0 +1,36 @@
+import React, { useRef } from 'react';
+import { useFBX } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
+import { Vector3 } from 'three';
+
+interface AsteroidProps {
+  startPosition?: [number, number, number];
+  speed?: number;
+  onReachTarget?: () => void;
+}
+
+export const Asteroid: React.FC<AsteroidProps> = ({
+  startPosition = [0, 5, -10],
+  speed = 0.02,
+  onReachTarget
+}) => {
+  const group = useRef<THREE.Group>(null);
+  const fbx = useFBX('/assets/asteroid_01.fbx');
+
+  useFrame(() => {
+    if (group.current) {
+      group.current.position.z += speed;
+      if (group.current.position.z >= 0) {
+        onReachTarget?.();
+      }
+    }
+  });
+
+  return (
+    <group ref={group} position={startPosition as Vector3}>
+      <primitive object={fbx.clone()} scale={0.005} />
+    </group>
+  );
+};
+
+

--- a/src/components/scifi/ScifiCannon.tsx
+++ b/src/components/scifi/ScifiCannon.tsx
@@ -1,0 +1,32 @@
+import React, { useRef, useEffect } from 'react';
+import { useFBX } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
+import { Vector3 } from 'three';
+
+interface ScifiCannonProps {
+  target?: Vector3;
+}
+
+export const ScifiCannon: React.FC<ScifiCannonProps> = ({ target }) => {
+  const group = useRef<THREE.Group>(null);
+  const fbx = useFBX('/assets/c1/scifi-cannon/source/300_Gun.fbx');
+
+  useFrame(() => {
+    if (group.current && target) {
+      group.current.lookAt(target);
+    }
+  });
+
+  // Scale down and rotate for better orientation
+  useEffect(() => {
+    if (group.current) {
+      group.current.rotation.x = Math.PI / 2;
+    }
+  }, []);
+
+  return (
+    <primitive ref={group} object={fbx.clone()} position={[0, -1.5, 4]} scale={0.003} />
+  );
+};
+
+

--- a/src/components/scifi/ScifiDefenseSystem.tsx
+++ b/src/components/scifi/ScifiDefenseSystem.tsx
@@ -1,0 +1,46 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { Vector3 } from 'three';
+import { ScifiCannon } from './ScifiCannon';
+import { Asteroid } from './Asteroid';
+
+interface SpawnedAsteroid {
+  id: number;
+  position: [number, number, number];
+}
+
+export const ScifiDefenseSystem: React.FC = () => {
+  const [asteroids, setAsteroids] = useState<SpawnedAsteroid[]>([]);
+  const intervalRef = useRef<NodeJS.Timeout>();
+
+  useEffect(() => {
+    intervalRef.current = setInterval(() => {
+      const x = Math.random() * 6 - 3;
+      const y = Math.random() * 2 + 3;
+      setAsteroids((prev) => [...prev, { id: Date.now(), position: [x, y, -10] }]);
+    }, 4000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  const handleAsteroidReach = useCallback((id: number) => {
+    setAsteroids((prev) => prev.filter((a) => a.id !== id));
+  }, []);
+
+  const target = asteroids[0] ? new Vector3(...asteroids[0].position) : undefined;
+
+  return (
+    <group>
+      <ScifiCannon target={target} />
+      {asteroids.map((ast) => (
+        <Asteroid
+          key={ast.id}
+          startPosition={ast.position}
+          onReachTarget={() => handleAsteroidReach(ast.id)}
+        />
+      ))}
+    </group>
+  );
+};
+
+


### PR DESCRIPTION
## Summary
- add simple Asteroid component using local FBX asset
- add ScifiCannon that aims at incoming asteroids
- create ScifiDefenseSystem spawner and integrate into Scene3D when in sci-fi realm

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684aeecadbf0832e8f449f338339123d