### PR TITLE
Add cannon projectiles and asteroid health

### DIFF
--- a/src/components/scifi/Asteroid.tsx
+++ b/src/components/scifi/Asteroid.tsx
@@ -2,16 +2,22 @@
 import React, { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Vector3, Group } from 'three';
+import { Html } from '@react-three/drei';
+import { Progress } from '../ui/progress';
+
+const MAX_HEALTH = 5;
 
 interface AsteroidProps {
   startPosition?: [number, number, number];
   speed?: number;
+  health: number;
   onReachTarget?: () => void;
 }
 
 export const Asteroid: React.FC<AsteroidProps> = ({
   startPosition = [0, 5, -10],
   speed = 0.02,
+  health,
   onReachTarget
 }) => {
   const group = useRef<Group>(null);
@@ -31,6 +37,11 @@ export const Asteroid: React.FC<AsteroidProps> = ({
         <icosahedronGeometry args={[1, 1]} />
         <meshStandardMaterial color="#888" />
       </mesh>
+      <Html position={[0, 1, 0]} center style={{ pointerEvents: 'none' }} transform distanceFactor={8}>
+        <div className="w-12">
+          <Progress value={Math.max(0, (health / MAX_HEALTH) * 100)} className="h-1" indicatorClassName={health <= 1 ? 'bg-red-600' : 'bg-green-500'} />
+        </div>
+      </Html>
     </group>
   );
 };

--- a/src/components/scifi/ScifiDefenseSystem.tsx
+++ b/src/components/scifi/ScifiDefenseSystem.tsx
@@ -7,22 +7,35 @@ import { Asteroid } from './Asteroid';
 interface SpawnedAsteroid {
   id: number;
   position: [number, number, number];
+  health: number;
+}
+
+interface Projectile {
+  id: number;
+  position: Vector3;
+  direction: Vector3;
+  speed: number;
 }
 
 export const ScifiDefenseSystem: React.FC = () => {
   const [asteroids, setAsteroids] = useState<SpawnedAsteroid[]>([]);
-  const intervalRef = useRef<NodeJS.Timeout>();
+  const [projectiles, setProjectiles] = useState<Projectile[]>([]);
+  const spawnIntervalRef = useRef<NodeJS.Timeout>();
+  const fireIntervalRef = useRef<NodeJS.Timeout>();
   const cannonGroup = useRef<Group>(null);
   const { camera } = useThree();
 
   useEffect(() => {
-    intervalRef.current = setInterval(() => {
+    spawnIntervalRef.current = setInterval(() => {
       const x = Math.random() * 6 - 3;
       const y = Math.random() * 2 + 3;
-      setAsteroids((prev) => [...prev, { id: Date.now(), position: [x, y, -10] }]);
+      setAsteroids((prev) => [
+        ...prev,
+        { id: Date.now(), position: [x, y, -10], health: 5 }
+      ]);
     }, 4000);
     return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
+      if (spawnIntervalRef.current) clearInterval(spawnIntervalRef.current);
     };
   }, []);
 
@@ -30,13 +43,63 @@ export const ScifiDefenseSystem: React.FC = () => {
     setAsteroids((prev) => prev.filter((a) => a.id !== id));
   }, []);
 
+  const handleAsteroidHit = useCallback((id: number, damage: number) => {
+    setAsteroids((prev) =>
+      prev.map((a) =>
+        a.id === id ? { ...a, health: a.health - damage } : a
+      ).filter((a) => a.health > 0)
+    );
+  }, []);
+
   // Keep cannon attached to the player's camera
-  const offset = useRef(new Vector3(1.5, -1, -2));
+  const offset = useRef(new Vector3(0, -1.5, -3));
   useFrame(() => {
     if (cannonGroup.current) {
       cannonGroup.current.position.copy(camera.position).add(offset.current);
       cannonGroup.current.quaternion.copy(camera.quaternion);
     }
+  });
+
+  // Fire projectiles at the closest asteroid
+  useEffect(() => {
+    fireIntervalRef.current = setInterval(() => {
+      if (!cannonGroup.current || asteroids.length === 0) return;
+      const start = new Vector3();
+      cannonGroup.current.getWorldPosition(start);
+      const targetPos = new Vector3(...asteroids[0].position);
+      const dir = targetPos.clone().sub(start).normalize();
+      setProjectiles((prev) => [
+        ...prev,
+        { id: Date.now(), position: start, direction: dir, speed: 0.5 }
+      ]);
+    }, 1000);
+    return () => {
+      if (fireIntervalRef.current) clearInterval(fireIntervalRef.current);
+    };
+  }, [asteroids]);
+
+  // Update projectiles each frame
+  useFrame(() => {
+    setProjectiles((prev) => {
+      return prev
+        .map((p) => {
+          const newPos = p.position
+            .clone()
+            .add(p.direction.clone().multiplyScalar(p.speed));
+          let hit = false;
+          for (const ast of asteroids) {
+            const astPos = new Vector3(...ast.position);
+            if (newPos.distanceTo(astPos) < 0.7) {
+              handleAsteroidHit(ast.id, 1);
+              hit = true;
+              break;
+            }
+          }
+          if (hit || newPos.distanceTo(camera.position) > 50) return null;
+          return { ...p, position: newPos } as Projectile;
+        })
+        .filter(Boolean) as Projectile[];
+    });
   });
 
   const target = asteroids[0] ? new Vector3(...asteroids[0].position) : undefined;
@@ -50,8 +113,15 @@ export const ScifiDefenseSystem: React.FC = () => {
         <Asteroid
           key={ast.id}
           startPosition={ast.position}
+          health={ast.health}
           onReachTarget={() => handleAsteroidReach(ast.id)}
         />
+      ))}
+      {projectiles.map((p) => (
+        <mesh key={p.id} position={p.position}>
+          <sphereGeometry args={[0.1, 8, 8]} />
+          <meshStandardMaterial color="#ff0000" />
+        </mesh>
       ))}
     </group>
   );


### PR DESCRIPTION
## Summary
- implement asteroid health UI
- spawn projectiles from the cannon
- reduce asteroid health when hit and keep cannon in view

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684b34ac0578832eb7e2bff4e3263355