### PR TITLE
Add asteroid asset with physics and crystal upgrades

### DIFF
--- a/src/components/EnhancedUpgradePedestal.tsx
+++ b/src/components/EnhancedUpgradePedestal.tsx
@@ -53,11 +53,12 @@ export const EnhancedUpgradePedestal: React.FC<EnhancedUpgradePedestalProps> = (
     }
   });
 
+  const tierColors = ['#a7f3d0', '#7dd3fc', '#818cf8', '#c084fc'];
   const getCrystalColor = () => {
-    if (isPurchased) return '#10B981'; // Green
-    if (isUnlocked && canAfford) return '#8B5CF6'; // Purple
-    if (isUnlocked) return '#6366F1'; // Blue
-    return '#6B7280'; // Gray
+    if (isPurchased) return '#10B981';
+    const base = tierColors[Math.min(tier - 1, tierColors.length - 1)] || '#6B7280';
+    if (isUnlocked) return base;
+    return '#6B7280';
   };
 
   const getPedestalTier = () => {
@@ -106,7 +107,10 @@ export const EnhancedUpgradePedestal: React.FC<EnhancedUpgradePedestalProps> = (
         scale={hovered ? 1.1 : 1}
         castShadow
       >
-        <octahedronGeometry args={[0.6]} />
+        {tier === 1 && <tetrahedronGeometry args={[0.5]} />}
+        {tier === 2 && <octahedronGeometry args={[0.6]} />}
+        {tier === 3 && <dodecahedronGeometry args={[0.7]} />}
+        {tier >= 4 && <icosahedronGeometry args={[0.8, 1]} />}
         <meshLambertMaterial
           color={getCrystalColor()}
           transparent

--- a/src/components/UpgradeNode3D.tsx
+++ b/src/components/UpgradeNode3D.tsx
@@ -26,29 +26,33 @@ export const UpgradeNode3D: React.FC<UpgradeNode3DProps> = React.memo(({
   const glowRef = useRef<Mesh>(null);
   const [hovered, setHovered] = useState(false);
 
-  // Memoize colors to prevent recalculation
+  const tierColors = ['#a7f3d0', '#7dd3fc', '#818cf8', '#c084fc'];
+
   const nodeColor = useMemo(() => {
-    if (isPurchased) return '#10b981'; // Green
-    if (isUnlocked && canAfford) return realm === 'fantasy' ? '#8b5cf6' : '#06b6d4';
-    if (isUnlocked) return realm === 'fantasy' ? '#6b46c1' : '#0e7490';
-    return '#6b7280'; // Gray
-  }, [isPurchased, isUnlocked, canAfford, realm]);
+    const base = tierColors[Math.min(upgrade.tier - 1, tierColors.length - 1)] || '#6b7280';
+    if (isPurchased) return '#10b981';
+    if (isUnlocked && canAfford) return base;
+    if (isUnlocked) return base;
+    return '#6b7280';
+  }, [isPurchased, isUnlocked, canAfford, upgrade.tier]);
 
   const glowColor = useMemo(() => {
     if (isPurchased) return '#34d399';
-    return realm === 'fantasy' ? '#c084fc' : '#67e8f9';
-  }, [isPurchased, realm]);
+    return tierColors[Math.min(upgrade.tier - 1, tierColors.length - 1)] || '#c084fc';
+  }, [isPurchased, upgrade.tier]);
 
-  // Memoize geometry based on upgrade type
   const geometry = useMemo(() => {
-    if (upgrade.id.includes('core') || upgrade.id.includes('engine')) {
-      return <octahedronGeometry args={[0.5]} />;
-    } else if (upgrade.id.includes('dragon') || upgrade.id.includes('beacon')) {
-      return <coneGeometry args={[0.5, 1, 6]} />;
-    } else {
-      return <dodecahedronGeometry args={[0.5]} />;
+    switch (upgrade.tier) {
+      case 1:
+        return <tetrahedronGeometry args={[0.4]} />;
+      case 2:
+        return <octahedronGeometry args={[0.5]} />;
+      case 3:
+        return <dodecahedronGeometry args={[0.6]} />;
+      default:
+        return <icosahedronGeometry args={[0.7, 1]} />;
     }
-  }, [upgrade.id]);
+  }, [upgrade.tier]);
 
   // Optimized animation with reduced frequency
   useFrame((state) => {

--- a/src/components/scifi/Asteroid.tsx
+++ b/src/components/scifi/Asteroid.tsx
@@ -2,29 +2,31 @@
 import React, { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Vector3, Group } from 'three';
-import { Html } from '@react-three/drei';
+import { Html, useFBX } from '@react-three/drei';
 import { Progress } from '../ui/progress';
 
 const MAX_HEALTH = 5;
 
 interface AsteroidProps {
-  startPosition?: [number, number, number];
-  speed?: number;
+  position: Vector3;
   health: number;
   onReachTarget?: () => void;
 }
 
 export const Asteroid: React.FC<AsteroidProps> = ({
-  startPosition = [0, 5, -10],
-  speed = 0.02,
+  position,
   health,
   onReachTarget
 }) => {
   const group = useRef<Group>(null);
+  const fbx = useFBX('/assets/asteroid_01.fbx');
 
   useFrame(() => {
     if (group.current) {
-      group.current.position.z += speed;
+      group.current.position.copy(position);
+      group.current.rotation.x += 0.01;
+      group.current.rotation.y += 0.005;
+
       if (group.current.position.z >= 0) {
         onReachTarget?.();
       }
@@ -32,14 +34,15 @@ export const Asteroid: React.FC<AsteroidProps> = ({
   });
 
   return (
-    <group ref={group} position={new Vector3(...startPosition)}>
-      <mesh scale={0.5}>
-        <icosahedronGeometry args={[1, 1]} />
-        <meshStandardMaterial color="#888" />
-      </mesh>
+    <group ref={group} position={position}>
+      <primitive object={fbx.clone()} scale={0.003} />
       <Html position={[0, 1, 0]} center style={{ pointerEvents: 'none' }} transform distanceFactor={8}>
         <div className="w-12">
-          <Progress value={Math.max(0, (health / MAX_HEALTH) * 100)} className="h-1" indicatorClassName={health <= 1 ? 'bg-red-600' : 'bg-green-500'} />
+          <Progress
+            value={Math.max(0, (health / MAX_HEALTH) * 100)}
+            className="h-1"
+            indicatorClassName={health <= 1 ? 'bg-red-600' : 'bg-green-500'}
+          />
         </div>
       </Html>
     </group>


### PR DESCRIPTION
## Summary
- load `asteroid_01.fbx` in `Asteroid` component and update to accept a moving position
- spawn asteroids off‑screen in `ScifiDefenseSystem`, aim them at upgrade targets and apply basic bounce physics
- tweak crystal pedestal colors/shapes by tier in `EnhancedUpgradePedestal`
- update upgrade nodes to show cooler crystals per tier

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684b35f17430832e8b9ee6a4a751dc23