### PR TITLE
Fix asteroid model and enable click shooting

### DIFF
--- a/src/components/OptimizedProjectileSystem.tsx
+++ b/src/components/OptimizedProjectileSystem.tsx
@@ -1,5 +1,5 @@
 
-import React, { useRef, useMemo } from 'react';
+import React, { useRef, useMemo, forwardRef, useImperativeHandle } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 
@@ -9,6 +9,10 @@ interface OptimizedProjectileSystemProps {
   damage: number;
   fireRate: number;
   onHitEnemy: (index: number, damage: number) => void;
+}
+
+export interface OptimizedProjectileSystemHandle {
+  manualFire: () => void;
 }
 
 interface ProjectileData {
@@ -25,13 +29,10 @@ const MAX_PROJECTILES = 20; // Pool size
 const PROJECTILE_SPEED = 25;
 const MAX_LIFE = 5; // Seconds
 
-export const OptimizedProjectileSystem: React.FC<OptimizedProjectileSystemProps> = ({
-  staffTipPosition,
-  targetPositions,
-  damage,
-  fireRate,
-  onHitEnemy
-}) => {
+export const OptimizedProjectileSystem = forwardRef<
+  OptimizedProjectileSystemHandle,
+  OptimizedProjectileSystemProps
+>(({ staffTipPosition, targetPositions, damage, fireRate, onHitEnemy }, ref) => {
   const projectilePoolRef = useRef<ProjectileData[]>([]);
   const meshPoolRef = useRef<THREE.Mesh[]>([]);
   const groupRef = useRef<THREE.Group>(null);
@@ -127,9 +128,16 @@ export const OptimizedProjectileSystem: React.FC<OptimizedProjectileSystemProps>
     // Setup mesh
     mesh.position.copy(staffPos);
     mesh.visible = true;
-    
+
     console.log('Fired projectile from', staffPos, 'to target', closestIndex, 'at position', targets[closestIndex]);
   };
+
+  const manualFire = () => {
+    fireProjectile(staffTipPosition, targetPositions);
+    lastFireTimeRef.current = Date.now();
+  };
+
+  useImperativeHandle(ref, () => ({ manualFire }), [manualFire]);
 
   useFrame((state, delta) => {
     const now = Date.now();
@@ -182,4 +190,4 @@ export const OptimizedProjectileSystem: React.FC<OptimizedProjectileSystemProps>
       <ambientLight intensity={0.8} color="#00ffff" />
     </group>
   );
-};
+});

--- a/src/components/StaffWeaponSystem.tsx
+++ b/src/components/StaffWeaponSystem.tsx
@@ -3,7 +3,10 @@ import React, { useEffect, useRef } from 'react';
 import { useThree, useFrame } from '@react-three/fiber';
 import { useGLTF } from '@react-three/drei';
 import * as THREE from 'three';
-import { OptimizedProjectileSystem } from './OptimizedProjectileSystem';
+import {
+  OptimizedProjectileSystem,
+  OptimizedProjectileSystemHandle
+} from './OptimizedProjectileSystem';
 
 interface StaffWeaponSystemProps {
   damage: number;
@@ -21,6 +24,7 @@ export const StaffWeaponSystem: React.FC<StaffWeaponSystemProps> = ({
   const { camera } = useThree();
   const staffGroupRef = useRef<THREE.Group>(null);
   const staffTipPositionRef = useRef<THREE.Vector3>(new THREE.Vector3());
+  const projectileSystemRef = useRef<OptimizedProjectileSystemHandle>(null);
   
   // Load staff model with proper path and error handling
   let staffScene = null;
@@ -33,6 +37,14 @@ export const StaffWeaponSystem: React.FC<StaffWeaponSystemProps> = ({
   
   // Calculate fire rate based on upgrades (faster with more upgrades)
   const fireRate = Math.max(200, 800 - (upgrades * 80));
+
+  useEffect(() => {
+    const handleClick = () => {
+      projectileSystemRef.current?.manualFire();
+    };
+    window.addEventListener('click', handleClick);
+    return () => window.removeEventListener('click', handleClick);
+  }, []);
 
   useFrame((state, delta) => {
     if (!staffGroupRef.current || !camera) return;
@@ -124,6 +136,7 @@ export const StaffWeaponSystem: React.FC<StaffWeaponSystemProps> = ({
 
       {/* Optimized projectile system */}
       <OptimizedProjectileSystem
+        ref={projectileSystemRef}
         staffTipPosition={staffTipPositionRef.current}
         targetPositions={enemyPositions}
         damage={damage}

--- a/src/components/scifi/Asteroid.tsx
+++ b/src/components/scifi/Asteroid.tsx
@@ -2,9 +2,8 @@
 import React, { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Vector3, Group } from 'three';
-import { Html, useFBX } from '@react-three/drei';
+import { Html } from '@react-three/drei';
 import { Progress } from '../ui/progress';
-import { assetPath } from '../../lib/assetPath';
 
 const MAX_HEALTH = 5;
 
@@ -20,7 +19,6 @@ export const Asteroid: React.FC<AsteroidProps> = ({
   onReachTarget
 }) => {
   const group = useRef<Group>(null);
-  const fbx = useFBX(assetPath('assets/asteroid_01.fbx'));
 
   useFrame(() => {
     if (group.current) {
@@ -36,7 +34,10 @@ export const Asteroid: React.FC<AsteroidProps> = ({
 
   return (
     <group ref={group} position={position}>
-      <primitive object={fbx.clone()} scale={0.003} />
+      <mesh>
+        <sphereGeometry args={[0.5, 16, 16]} />
+        <meshStandardMaterial color="#888888" />
+      </mesh>
       <Html position={[0, 1, 0]} center style={{ pointerEvents: 'none' }} transform distanceFactor={8}>
         <div className="w-12">
           <Progress

--- a/src/components/scifi/ScifiDefenseSystem.tsx
+++ b/src/components/scifi/ScifiDefenseSystem.tsx
@@ -61,6 +61,22 @@ export const ScifiDefenseSystem: React.FC = () => {
     };
   }, [camera]);
 
+  useEffect(() => {
+    const handleClick = () => {
+      if (!cannonGroup.current || asteroids.length === 0) return;
+      const start = new Vector3();
+      cannonGroup.current.getWorldPosition(start);
+      const targetPos = asteroids[0].position.clone();
+      const dir = targetPos.clone().sub(start).normalize();
+      setProjectiles(prev => [
+        ...prev,
+        { id: Date.now(), position: start, direction: dir, speed: 0.5 }
+      ]);
+    };
+    window.addEventListener('click', handleClick);
+    return () => window.removeEventListener('click', handleClick);
+  }, [asteroids]);
+
   const handleAsteroidHit = useCallback((id: number, damage: number) => {
     setAsteroids((prev) =>
       prev.map((a) =>


### PR DESCRIPTION
## Summary
- replace missing asteroid FBX model with a simple sphere placeholder
- expose `manualFire` on `OptimizedProjectileSystem` to allow manual shots
- shoot projectiles on click in `StaffWeaponSystem`
- shoot projectiles on click in the sci‑fi defense system

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684b3ae7121c832ebc055937f286c5e4