### PR TITLE
Reduce asteroid speed for better gameplay

### DIFF
--- a/src/components/scifi/ScifiDefenseSystem.tsx
+++ b/src/components/scifi/ScifiDefenseSystem.tsx
@@ -51,7 +51,10 @@ export const ScifiDefenseSystem: React.FC = () => {
         {
           id: Date.now(),
           position: spawnPos,
-          velocity: dir.multiplyScalar(0.2),
+          // Asteroids were moving too quickly to react to. Reduce
+          // their velocity so players have a fair chance to shoot
+          // them down before they reach the target area.
+          velocity: dir.multiplyScalar(0.05),
           health: 5
         }
       ]);


### PR DESCRIPTION
## Summary
- slow down asteroids so they are easier to hit

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684b3d2a071c832eac9bde523a734866