### PR TITLE
Add scifi weapon upgrades with cross‑realm synergy

### DIFF
--- a/src/components/GameEngine.tsx
+++ b/src/components/GameEngine.tsx
@@ -10,6 +10,7 @@ import { QuickHelpModal } from './QuickHelpModal';
 import { CombatUpgradeSystem } from './CombatUpgradeSystem';
 import { JourneyTracker } from './JourneyTracker';
 import { WeaponUpgradeSystem } from './WeaponUpgradeSystem';
+import { ScifiWeaponUpgradeSystem } from './ScifiWeaponUpgradeSystem';
 import { CrossRealmUpgradeSystem } from './CrossRealmUpgradeSystem';
 import { useGameStateManager, fantasyBuildings, scifiBuildings } from './GameStateManager';
 import { useGameLoopManager } from './GameLoopManager';
@@ -87,12 +88,15 @@ const GameEngine: React.FC = () => {
   const {
     combatUpgrades,
     weaponUpgrades,
+    scifiWeaponUpgrades,
     weaponStats,
+    scifiWeaponStats,
     buyBuilding,
     performConvergence,
     purchaseUpgrade,
     purchaseCombatUpgrade,
     purchaseWeaponUpgrade,
+    purchaseScifiWeaponUpgrade,
     purchaseCrossRealmUpgrade
   } = useUpgradeManagers({
     gameState: stableGameState,
@@ -279,7 +283,7 @@ const GameEngine: React.FC = () => {
           onPlayerPositionUpdate={handlePlayerPositionUpdate}
           onEnemyCountChange={handleEnemyCountChange}
           onEnemyKilled={handleEnemyKilled}
-          weaponDamage={weaponStats.damage}
+          weaponDamage={currentRealm === 'fantasy' ? weaponStats.damage : scifiWeaponStats.damage}
         />
 
         {/* Realm Transition Effect */}
@@ -349,12 +353,21 @@ const GameEngine: React.FC = () => {
 
       {/* Weapon Upgrades Modal */}
       {showWeaponUpgrades && (
-        <WeaponUpgradeSystem
-          upgrades={weaponUpgrades}
-          mana={stableGameState.mana}
-          onUpgrade={purchaseWeaponUpgrade}
-          onClose={() => setShowWeaponUpgrades(false)}
-        />
+        currentRealm === 'fantasy' ? (
+          <WeaponUpgradeSystem
+            upgrades={weaponUpgrades}
+            mana={stableGameState.mana}
+            onUpgrade={purchaseWeaponUpgrade}
+            onClose={() => setShowWeaponUpgrades(false)}
+          />
+        ) : (
+          <ScifiWeaponUpgradeSystem
+            upgrades={scifiWeaponUpgrades}
+            energyCredits={stableGameState.energyCredits}
+            onUpgrade={purchaseScifiWeaponUpgrade}
+            onClose={() => setShowWeaponUpgrades(false)}
+          />
+        )
       )}
 
       {/* Cross-Realm Upgrades Modal */}

--- a/src/components/GameStateManager.tsx
+++ b/src/components/GameStateManager.tsx
@@ -16,6 +16,7 @@ export interface GameState {
   lastSaveTime: number;
   combatUpgrades: { [key: string]: number };
   weaponUpgrades?: { [key: string]: number };
+  scifiWeaponUpgrades?: { [key: string]: number };
   crossRealmUpgrades?: { [key: string]: number };
   fantasyJourneyDistance: number;
   scifiJourneyDistance: number;
@@ -65,6 +66,7 @@ const defaultGameState: GameState = {
   lastSaveTime: Date.now(),
   combatUpgrades: {},
   weaponUpgrades: {},
+  scifiWeaponUpgrades: {},
   crossRealmUpgrades: {},
   fantasyJourneyDistance: 0,
   scifiJourneyDistance: 0,
@@ -86,6 +88,7 @@ export const useGameStateManager = () => {
         lastSaveTime: parsedState.lastSaveTime || Date.now(),
         combatUpgrades: parsedState.combatUpgrades || {},
         weaponUpgrades: parsedState.weaponUpgrades || {},
+        scifiWeaponUpgrades: parsedState.scifiWeaponUpgrades || {},
         crossRealmUpgrades: parsedState.crossRealmUpgrades || {},
         fantasyJourneyDistance: parsedState.fantasyJourneyDistance || 0,
         scifiJourneyDistance: parsedState.scifiJourneyDistance || 0,

--- a/src/components/ScifiWeaponUpgradeSystem.tsx
+++ b/src/components/ScifiWeaponUpgradeSystem.tsx
@@ -1,0 +1,152 @@
+
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { X } from 'lucide-react';
+
+export interface ScifiWeaponUpgrade {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  level: number;
+  maxLevel: number;
+  baseCost: number;
+  effect: {
+    damage?: number;
+    fireRate?: number;
+    range?: number;
+  };
+}
+
+interface ScifiWeaponUpgradeSystemProps {
+  upgrades: ScifiWeaponUpgrade[];
+  energyCredits: number;
+  onUpgrade: (upgradeId: string) => void;
+  onClose: () => void;
+}
+
+export const ScifiWeaponUpgradeSystem: React.FC<ScifiWeaponUpgradeSystemProps> = ({
+  upgrades,
+  energyCredits,
+  onUpgrade,
+  onClose
+}) => {
+  const calculateCost = (upgrade: ScifiWeaponUpgrade): number => {
+    return Math.floor(upgrade.baseCost * Math.pow(1.8, upgrade.level));
+  };
+
+  const canAfford = (upgrade: ScifiWeaponUpgrade): boolean => {
+    return energyCredits >= calculateCost(upgrade) && upgrade.level < upgrade.maxLevel;
+  };
+
+  return (
+    <div 
+      className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50"
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '12px',
+        boxSizing: 'border-box'
+      }}
+    >
+      <div 
+        className="bg-gradient-to-br from-cyan-900/95 to-blue-800/95 backdrop-blur-xl rounded-xl border border-cyan-400/30 overflow-hidden"
+        style={{
+          width: '320px',
+          maxWidth: '320px',
+          height: '450px',
+          maxHeight: '450px',
+          boxSizing: 'border-box',
+          borderRadius: '12px'
+        }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-3 border-b border-cyan-400/20 flex-shrink-0">
+          <h2 className="text-sm font-bold text-white flex items-center gap-2">
+            🚀 Sci-Fi Weapon Upgrades
+          </h2>
+          <Button
+            onClick={onClose}
+            size="sm"
+            variant="ghost"
+            className="h-6 w-6 p-0 text-white/70 hover:text-white hover:bg-white/10"
+          >
+            <X size={12} />
+          </Button>
+        </div>
+
+        {/* Upgrades List */}
+        <div 
+          className="p-3 space-y-2"
+          style={{
+            height: '400px',
+            overflowY: 'auto',
+            overflowX: 'hidden'
+          }}
+        >
+          {upgrades.map(upgrade => {
+            const cost = calculateCost(upgrade);
+            const affordable = canAfford(upgrade);
+            const maxed = upgrade.level >= upgrade.maxLevel;
+
+            return (
+              <div
+                key={upgrade.id}
+                className="bg-black/40 rounded-lg p-3 border border-cyan-400/20 hover:border-cyan-400/40 transition-all duration-200"
+              >
+                <div className="flex items-start justify-between mb-2">
+                  <div className="flex items-center gap-2">
+                    <span className="text-lg">{upgrade.icon}</span>
+                    <div>
+                      <h3 className="font-semibold text-white text-xs">{upgrade.name}</h3>
+                      <p className="text-cyan-300 text-xs">{upgrade.description}</p>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <div className="text-yellow-400 font-bold text-xs">
+                      Level {upgrade.level}/{upgrade.maxLevel}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Effect Display */}
+                <div className="mb-2 text-xs text-cyan-200">
+                  {upgrade.effect.damage && (
+                    <div>Damage: +{upgrade.effect.damage * upgrade.level}</div>
+                  )}
+                  {upgrade.effect.fireRate && (
+                    <div>Fire Rate: -{upgrade.effect.fireRate * upgrade.level}ms</div>
+                  )}
+                  {upgrade.effect.range && (
+                    <div>Range: +{upgrade.effect.range * upgrade.level}m</div>
+                  )}
+                </div>
+
+                {/* Upgrade Button */}
+                <Button
+                  onClick={() => onUpgrade(upgrade.id)}
+                  disabled={!affordable || maxed}
+                  className={`w-full h-7 text-xs ${
+                    maxed
+                      ? 'bg-gray-600 text-gray-400 cursor-not-allowed'
+                      : affordable
+                      ? 'bg-cyan-600 hover:bg-cyan-700 text-white'
+                      : 'bg-gray-700 text-gray-400 cursor-not-allowed'
+                  }`}
+                >
+                  {maxed ? 'MAX LEVEL' : `Upgrade (${cost} Energy)`}
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- create `ScifiWeaponUpgradeSystem` component to handle energy based upgrades
- extend `GameState` to store `scifiWeaponUpgrades`
- update `UpgradeManagers` with default scifi upgrades and purchase logic
- render correct weapon upgrade UI per realm and apply cross bonuses

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b3e059ce0832eb76ca705f4f7e102