### PR TITLE
Add energy reward for destroyed meteors

### DIFF
--- a/src/components/GameEngine.tsx
+++ b/src/components/GameEngine.tsx
@@ -123,6 +123,13 @@ const GameEngine: React.FC = () => {
     }));
   }, [setGameState]);
 
+  const handleMeteorDestroyed = useCallback(() => {
+    setGameState(prev => ({
+      ...prev,
+      energyCredits: prev.energyCredits + 5,
+    }));
+  }, [setGameState]);
+
   const handleJourneyUpdate = useCallback((distance: number) => {
     const currentDistance = currentRealm === 'fantasy' ? stableGameState.fantasyJourneyDistance : stableGameState.scifiJourneyDistance;
     
@@ -283,6 +290,7 @@ const GameEngine: React.FC = () => {
           onPlayerPositionUpdate={handlePlayerPositionUpdate}
           onEnemyCountChange={handleEnemyCountChange}
           onEnemyKilled={handleEnemyKilled}
+          onMeteorDestroyed={handleMeteorDestroyed}
           weaponDamage={currentRealm === 'fantasy' ? weaponStats.damage : scifiWeaponStats.damage}
         />
 

--- a/src/components/MapSkillTreeView.tsx
+++ b/src/components/MapSkillTreeView.tsx
@@ -25,6 +25,7 @@ interface MapSkillTreeViewProps {
   onPlayerPositionUpdate?: (position: { x: number; y: number; z: number }) => void;
   onEnemyCountChange?: (count: number) => void;
   onEnemyKilled?: () => void;
+  onMeteorDestroyed?: () => void;
   weaponDamage: number;
 }
 
@@ -44,6 +45,7 @@ export const MapSkillTreeView: React.FC<MapSkillTreeViewProps> = ({
   onPlayerPositionUpdate,
   onEnemyCountChange,
   onEnemyKilled,
+  onMeteorDestroyed,
   weaponDamage
 }) => {
   console.log('MapSkillTreeView: Rendering with realm:', realm);
@@ -129,6 +131,7 @@ export const MapSkillTreeView: React.FC<MapSkillTreeViewProps> = ({
             isTransitioning={isTransitioning}
             showTapEffect={showTapEffect}
             onTapEffectComplete={onTapEffectComplete}
+            onMeteorDestroyed={onMeteorDestroyed}
           />
         )}
 

--- a/src/components/Scene3D.tsx
+++ b/src/components/Scene3D.tsx
@@ -22,6 +22,7 @@ interface Scene3DProps {
   isTransitioning?: boolean;
   showTapEffect?: boolean;
   onTapEffectComplete?: () => void;
+  onMeteorDestroyed?: () => void;
 }
 
 // Memoized upgrade positions - no need to recalculate every render
@@ -42,7 +43,8 @@ export const Scene3D: React.FC<Scene3DProps> = React.memo(({
   onUpgradeClick,
   isTransitioning = false,
   showTapEffect = false,
-  onTapEffectComplete
+  onTapEffectComplete,
+  onMeteorDestroyed
 }) => {
   console.log('Scene3D: Rendering with realm:', realm);
   
@@ -125,7 +127,7 @@ export const Scene3D: React.FC<Scene3DProps> = React.memo(({
           <ImprovedFantasyLighting />
 
           <FloatingIsland realm={realm} />
-          {realm === 'scifi' && <ScifiDefenseSystem />}
+          {realm === 'scifi' && <ScifiDefenseSystem onMeteorDestroyed={onMeteorDestroyed} />}
 
           {/* Fantasy environment with polygon mountains removed and fixed tree positioning */}
           {realm === 'fantasy' && (


### PR DESCRIPTION
## Summary
- grant bonus energy when a meteor is destroyed
- wire meteor-destroyed callback through Scene3D and GameEngine

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b401912f8832e9dbca5b7b35ed940