### PR TITLE
Limit scifi meteor spam

### DIFF
--- a/src/components/FloatingIsland.tsx
+++ b/src/components/FloatingIsland.tsx
@@ -50,25 +50,26 @@ export const FloatingIsland: React.FC<FloatingIslandProps> = ({ realm }) => {
         />
       </mesh>
 
-      {/* Ambient particles around island */}
-      <points>
-        <bufferGeometry>
-          <bufferAttribute
-            attach="attributes-position"
-            count={50}
-            array={new Float32Array(
-              Array.from({ length: 50 * 3 }, () => (Math.random() - 0.5) * 10)
-            )}
-            itemSize={3}
+      {realm === 'fantasy' && (
+        <points>
+          <bufferGeometry>
+            <bufferAttribute
+              attach="attributes-position"
+              count={50}
+              array={new Float32Array(
+                Array.from({ length: 50 * 3 }, () => (Math.random() - 0.5) * 10)
+              )}
+              itemSize={3}
+            />
+          </bufferGeometry>
+          <pointsMaterial
+            size={0.02}
+            color="#c084fc"
+            transparent
+            opacity={0.6}
           />
-        </bufferGeometry>
-        <pointsMaterial
-          size={0.02}
-          color={realm === 'fantasy' ? '#c084fc' : '#67e8f9'}
-          transparent
-          opacity={0.6}
-        />
-      </points>
+        </points>
+      )}
     </group>
   );
 };


### PR DESCRIPTION
## Summary
- constrain scifi meteors to the visible screen and limit spawn count
- auto-fire at only visible meteors
- remove floating particles from the scifi floating island

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c563e9b7c832e8acaffa6cc9a1370