### PR TITLE
Fix scifi projectile targeting

### DIFF
--- a/src/components/scifi/ScifiDefenseSystem.tsx
+++ b/src/components/scifi/ScifiDefenseSystem.tsx
@@ -70,7 +70,12 @@ export const ScifiDefenseSystem: React.FC<ScifiDefenseSystemProps> = ({ onMeteor
   const isAsteroidVisible = useCallback(
     (pos: Vector3) => {
       const ndc = pos.clone().project(camera);
-      return Math.abs(ndc.x) <= 1 && Math.abs(ndc.y) <= 1 && ndc.z < 1;
+      return (
+        Math.abs(ndc.x) <= 1 &&
+        Math.abs(ndc.y) <= 1 &&
+        ndc.z >= -1 &&
+        ndc.z <= 1
+      );
     },
     [camera]
   );


### PR DESCRIPTION
## Summary
- ensure meteors are considered visible only when inside camera frustum

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c5808a078832e80a2d720df824a4b