### PR TITLE
Fix upgrade purchase duplication and use orb projectile model

### DIFF
--- a/src/components/OptimizedProjectileSystem.tsx
+++ b/src/components/OptimizedProjectileSystem.tsx
@@ -40,13 +40,15 @@ export const OptimizedProjectileSystem = forwardRef<
   const groupRef = useRef<THREE.Group>(null);
   const lastFireTimeRef = useRef(0);
 
-  // Load lightning bolt models for projectiles
-  const { scene: lightningScene } = useGLTF(assetPath('assets/3_pack_of_storm_lightning.glb'));
-  const lightningBolts = useMemo<THREE.Object3D[]>(() => {
-    return lightningScene ? lightningScene.children.map(child => child.clone()) : [];
-  }, [lightningScene]);
-  
-  // Scale applied to lightning bolt models
+  // Load orb model for projectiles
+  const { scene: orbScene } = useGLTF(
+    assetPath('assets/orb/uttm_core_accurate.glb')
+  );
+  const orbModel = useMemo<THREE.Object3D | null>(() => {
+    return orbScene ? orbScene.clone() : null;
+  }, [orbScene]);
+
+  // Scale applied to orb model
   const projectileScale = 0.5;
 
   // Initialize projectile pool
@@ -115,16 +117,15 @@ export const OptimizedProjectileSystem = forwardRef<
     const projectile = projectilePoolRef.current[projectileIndex];
     const mesh = meshPoolRef.current[projectileIndex];
 
-    // Attach a random lightning bolt model
-    if (lightningBolts.length > 0) {
+    // Attach orb model
+    if (orbModel) {
       // remove previous model but keep light as first child
       while (mesh.children.length > 1) {
         mesh.remove(mesh.children[1]);
       }
-      const boltIndex = Math.floor(Math.random() * lightningBolts.length);
-      const bolt = lightningBolts[boltIndex].clone();
-      bolt.scale.setScalar(projectileScale);
-      mesh.add(bolt);
+      const orb = orbModel.clone();
+      orb.scale.setScalar(projectileScale);
+      mesh.add(orb);
     }
     
     // Setup projectile
@@ -202,4 +203,4 @@ export const OptimizedProjectileSystem = forwardRef<
   );
 });
 
-useGLTF.preload(assetPath('assets/3_pack_of_storm_lightning.glb'));
+useGLTF.preload(assetPath('assets/orb/uttm_core_accurate.glb'));

--- a/src/components/UpgradeManagers.tsx
+++ b/src/components/UpgradeManagers.tsx
@@ -281,11 +281,16 @@ export const useUpgradeManagers = ({
     const upgrade = enhancedHybridUpgrades.find(u => u.id === upgradeId);
     if (!upgrade || gameState.nexusShards < upgrade.cost) return;
 
-    setGameState(prev => ({
-      ...prev,
-      nexusShards: prev.nexusShards - upgrade.cost,
-      purchasedUpgrades: [...prev.purchasedUpgrades, upgradeId]
-    }));
+    setGameState(prev => {
+      if (prev.purchasedUpgrades.includes(upgradeId)) {
+        return prev; // already purchased
+      }
+      return {
+        ...prev,
+        nexusShards: prev.nexusShards - upgrade.cost,
+        purchasedUpgrades: [...prev.purchasedUpgrades, upgradeId]
+      };
+    });
   }, [gameState.nexusShards, setGameState]);
 
   const purchaseCombatUpgrade = useCallback((upgradeId: string) => {


### PR DESCRIPTION
## Summary
- load `assets/orb/uttm_core_accurate.glb` for staff projectiles
- prevent buying the same upgrade more than once

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685188142408832eb674fdfd532199fa