### PR TITLE
Fix projectile movement and allow upgrade interaction

### DIFF
--- a/src/components/MagicStaffWeaponSystem.tsx
+++ b/src/components/MagicStaffWeaponSystem.tsx
@@ -211,10 +211,9 @@ export const MagicStaffWeaponSystem: React.FC<MagicStaffWeaponSystemProps> = ({
 
   // FIXED: Use canvas-specific click handler instead of window
   useEffect(() => {
-    const handleClick = (event: MouseEvent) => {
-      event.preventDefault();
-      event.stopPropagation();
-      
+    const handleClick = () => {
+      // Allow upgrade pedestals to receive their click events by not
+      // stopping propagation or preventing default behaviour.
       console.log('MagicStaffWeaponSystem: Canvas clicked - manual fire triggered');
       projectileSystemRef.current?.manualFire();
     };
@@ -272,18 +271,21 @@ export const MagicStaffWeaponSystem: React.FC<MagicStaffWeaponSystemProps> = ({
   }
 
   return (
-    <group ref={weaponGroupRef}>
-      <primitive
-        object={staffModel}
-        scale={[staffScale, staffScale, staffScale]}
-      />
-      {/* Enhanced staff tip indicator (visible point where projectiles spawn) */}
-      <mesh position={[0, 1.8 * staffScale, 0]}>
-        <sphereGeometry args={[0.02]} />
-        <meshBasicMaterial color="#00ffff" emissive="#00ffff" emissiveIntensity={0.8} />
-      </mesh>
-      {/* Reduced light intensity to match smaller staff */}
-      <pointLight position={[0, 0.5, 0]} color="#4B0082" intensity={0.3} distance={2} />
+    <>
+      <group ref={weaponGroupRef}>
+        <primitive
+          object={staffModel}
+          scale={[staffScale, staffScale, staffScale]}
+        />
+        {/* Enhanced staff tip indicator (visible point where projectiles spawn) */}
+        <mesh position={[0, 1.8 * staffScale, 0]}>
+          <sphereGeometry args={[0.02]} />
+          <meshBasicMaterial color="#00ffff" emissive="#00ffff" emissiveIntensity={0.8} />
+        </mesh>
+        {/* Reduced light intensity to match smaller staff */}
+        <pointLight position={[0, 0.5, 0]} color="#4B0082" intensity={0.3} distance={2} />
+      </group>
+      {/* Render projectiles outside of the weapon group so they aren't tied to the camera */}
       <OptimizedProjectileSystem
         ref={projectileSystemRef}
         staffTipPosition={staffTipPositionRef.current}
@@ -292,7 +294,7 @@ export const MagicStaffWeaponSystem: React.FC<MagicStaffWeaponSystemProps> = ({
         autoFireRate={autoFireRate}
         onHitEnemy={onHitEnemy}
       />
-    </group>
+    </>
   );
 };
 

--- a/src/components/StaffWeaponSystem.tsx
+++ b/src/components/StaffWeaponSystem.tsx
@@ -41,11 +41,9 @@ export const StaffWeaponSystem: React.FC<StaffWeaponSystemProps> = ({
 
   // FIXED: Attach click handler to the canvas specifically, not window
   useEffect(() => {
-    const handleClick = (event: MouseEvent) => {
-      // Prevent default to avoid any conflicts
-      event.preventDefault();
-      event.stopPropagation();
-      
+    const handleClick = () => {
+      // Simply trigger a manual shot without interfering with other click
+      // handlers in the scene.
       console.log('Canvas clicked - manual fire triggered');
       projectileSystemRef.current?.manualFire();
     };


### PR DESCRIPTION
## Summary
- keep projectiles independent from the camera by rendering them outside the weapon group
- stop blocking click propagation so upgrade pedestals can be clicked

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862b487f2d4832ebc6ff642c8479e38