### PR TITLE
Fix purchase state for 3D upgrades

### DIFF
--- a/src/components/Fantasy3DUpgradeModal.tsx
+++ b/src/components/Fantasy3DUpgradeModal.tsx
@@ -8,7 +8,7 @@ interface Fantasy3DUpgradeModalProps {
   upgradeData: {
     cost: number;
     manaPerSecond: number;
-    unlocked: boolean;
+    purchased: boolean;
   };
 }
 
@@ -56,10 +56,10 @@ export const Fantasy3DUpgradeModal: React.FC<Fantasy3DUpgradeModalProps> = ({
           
           <button
             onClick={onPurchase}
-            disabled={upgradeData.unlocked}
+            disabled={upgradeData.purchased}
             className="flex-1 px-3 py-2 bg-purple-600/80 hover:bg-purple-500/80 disabled:bg-gray-600/50 disabled:cursor-not-allowed rounded-lg transition-colors min-h-[36px] text-xs"
           >
-            {upgradeData.unlocked ? 'Owned' : 'Purchase'}
+            {upgradeData.purchased ? 'Owned' : 'Purchase'}
           </button>
         </div>
       </div>

--- a/src/components/Fantasy3DUpgradeWorld.tsx
+++ b/src/components/Fantasy3DUpgradeWorld.tsx
@@ -181,7 +181,7 @@ export const Fantasy3DUpgradeWorld: React.FC<Fantasy3DUpgradeWorldProps> = ({
                 upgradeData={{
                   cost: selectedUpgrade.cost,
                   manaPerSecond: selectedUpgrade.manaPerSecond,
-                  unlocked: selectedUpgrade.unlocked
+                  purchased: purchasedUpgrades.has(selectedUpgrade.id)
                 }}
               />
             </div>

--- a/src/components/MapSkillTreeView.tsx
+++ b/src/components/MapSkillTreeView.tsx
@@ -205,7 +205,7 @@ export const MapSkillTreeView: React.FC<MapSkillTreeViewProps> = ({
                 upgradeData={{
                   cost: 100,
                   manaPerSecond: 10,
-                  unlocked: false
+                  purchased: false
                 }}
               />
             </div>


### PR DESCRIPTION
## Summary
- track whether fantasy upgrades are owned instead of unlocked
- pass purchase state to the modal so upgrades don't start as owned

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862bb9b8f98832e942cfb61c1c6cb57