### PR TITLE
Enhance upgrade effects

### DIFF
--- a/src/components/Fantasy3DScene.tsx
+++ b/src/components/Fantasy3DScene.tsx
@@ -23,6 +23,7 @@ interface Fantasy3DSceneProps {
   onEnemyCountChange?: (count: number) => void;
   onEnemyKilled?: () => void;
   weaponDamage: number;
+  upgradesPurchased?: number;
 }
 
 interface LeechData {
@@ -42,7 +43,8 @@ export const Fantasy3DScene: React.FC<Fantasy3DSceneProps> = React.memo(({
   onEnemyCountChange,
   onEnemyKilled,
   maxUnlockedUpgrade,
-  weaponDamage
+  weaponDamage,
+  upgradesPurchased = 0
 }) => {
   const [leeches, setLeeches] = useState<LeechData[]>([]);
   const [nextLeechId, setNextLeechId] = useState(0);
@@ -58,7 +60,9 @@ export const Fantasy3DScene: React.FC<Fantasy3DSceneProps> = React.memo(({
   // Enemies spawn slightly faster to keep the action flowing
   useEffect(() => {
     const playerProgress = Math.abs(safeCameraPosition.z);
-    const desiredLeechCount = Math.min(Math.floor(playerProgress / 40) + 2, 4);
+    const baseCount = Math.floor(playerProgress / 40) + 2;
+    const extra = Math.floor(upgradesPurchased / 2);
+    const desiredLeechCount = Math.min(baseCount + extra, 10);
     
     setLeeches(currentLeeches => {
       const aliveLeeches = currentLeeches.filter(leech => leech.alive);
@@ -87,7 +91,7 @@ export const Fantasy3DScene: React.FC<Fantasy3DSceneProps> = React.memo(({
       
       return currentLeeches;
     });
-  }, [Math.floor(Math.abs(safeCameraPosition.z) / 50), nextLeechId]); // Reduced frequency
+  }, [Math.floor(Math.abs(safeCameraPosition.z) / 50), nextLeechId, upgradesPurchased]);
 
   // Update enemy count for UI
   useEffect(() => {

--- a/src/components/Fantasy3DUpgradeWorld.tsx
+++ b/src/components/Fantasy3DUpgradeWorld.tsx
@@ -19,6 +19,7 @@ interface Fantasy3DUpgradeWorldProps {
   onEnemyCountChange?: (count: number) => void;
   onEnemyKilled?: () => void;
   weaponDamage: number;
+  upgradesPurchased?: number;
 }
 
 export const Fantasy3DUpgradeWorld: React.FC<Fantasy3DUpgradeWorldProps> = ({
@@ -30,7 +31,8 @@ export const Fantasy3DUpgradeWorld: React.FC<Fantasy3DUpgradeWorldProps> = ({
   onPlayerPositionUpdate,
   onEnemyCountChange,
   onEnemyKilled,
-  weaponDamage
+  weaponDamage,
+  upgradesPurchased = 0
 }) => {
   console.log('Fantasy3DUpgradeWorld: Rendering with realm:', realm);
   
@@ -144,6 +146,7 @@ export const Fantasy3DUpgradeWorld: React.FC<Fantasy3DUpgradeWorldProps> = ({
               onEnemyCountChange={onEnemyCountChange}
               onEnemyKilled={onEnemyKilled}
               weaponDamage={weaponDamage}
+              upgradesPurchased={upgradesPurchased}
             />
 
             <Fantasy3DUpgradePedestals

--- a/src/components/GameEngine.tsx
+++ b/src/components/GameEngine.tsx
@@ -281,18 +281,19 @@ const GameEngine: React.FC = () => {
           energyPerSecond={stableGameState.energyPerSecond}
           onBuyBuilding={(buildingId) => buyBuilding(buildingId, currentRealm === 'fantasy')}
           buildingData={currentRealm === 'fantasy' ? fantasyBuildings : scifiBuildings}
-          currency={currentRealm === 'fantasy' ? stableGameState.mana : stableGameState.energyCredits}
-          gameState={stableGameState}
-          onPurchaseUpgrade={purchaseUpgrade}
-          isTransitioning={isTransitioning}
-          showTapEffect={showTapEffect}
-          onTapEffectComplete={handleTapEffectComplete}
-          onPlayerPositionUpdate={handlePlayerPositionUpdate}
-          onEnemyCountChange={handleEnemyCountChange}
-          onEnemyKilled={handleEnemyKilled}
-          onMeteorDestroyed={handleMeteorDestroyed}
-          weaponDamage={currentRealm === 'fantasy' ? weaponStats.damage : scifiWeaponStats.damage}
-        />
+        currency={currentRealm === 'fantasy' ? stableGameState.mana : stableGameState.energyCredits}
+        gameState={stableGameState}
+        onPurchaseUpgrade={purchaseUpgrade}
+        isTransitioning={isTransitioning}
+        showTapEffect={showTapEffect}
+        onTapEffectComplete={handleTapEffectComplete}
+        onPlayerPositionUpdate={handlePlayerPositionUpdate}
+        onEnemyCountChange={handleEnemyCountChange}
+        onEnemyKilled={handleEnemyKilled}
+        onMeteorDestroyed={handleMeteorDestroyed}
+        weaponDamage={currentRealm === 'fantasy' ? weaponStats.damage : scifiWeaponStats.damage}
+        upgradesPurchased={stableGameState.purchasedUpgrades.length}
+      />
 
         {/* Realm Transition Effect */}
         <RealmTransition currentRealm={currentRealm} isTransitioning={isTransitioning} />

--- a/src/components/MapSkillTreeView.tsx
+++ b/src/components/MapSkillTreeView.tsx
@@ -27,6 +27,7 @@ interface MapSkillTreeViewProps {
   onEnemyKilled?: () => void;
   onMeteorDestroyed?: () => void;
   weaponDamage: number;
+  upgradesPurchased?: number;
 }
 
 export const MapSkillTreeView: React.FC<MapSkillTreeViewProps> = ({
@@ -46,7 +47,8 @@ export const MapSkillTreeView: React.FC<MapSkillTreeViewProps> = ({
   onEnemyCountChange,
   onEnemyKilled,
   onMeteorDestroyed,
-  weaponDamage
+  weaponDamage,
+  upgradesPurchased = 0
 }) => {
   console.log('MapSkillTreeView: Rendering with realm:', realm);
   
@@ -121,6 +123,7 @@ export const MapSkillTreeView: React.FC<MapSkillTreeViewProps> = ({
             onEnemyCountChange={onEnemyCountChange}
             onEnemyKilled={onEnemyKilled}
             weaponDamage={weaponDamage}
+            upgradesPurchased={gameState.purchasedUpgrades?.length || 0}
           />
         ) : (
           <Scene3D

--- a/src/components/UpgradeManagers.tsx
+++ b/src/components/UpgradeManagers.tsx
@@ -281,6 +281,13 @@ export const useUpgradeManagers = ({
     const upgrade = enhancedHybridUpgrades.find(u => u.id === upgradeId);
     if (!upgrade || gameState.nexusShards < upgrade.cost) return;
 
+    const totalUpgrades = gameState.purchasedUpgrades.length;
+    const specialUpgradeLevel = gameState.crossRealmUpgrades?.['scifi_gravity_well'] || 0;
+    if ((totalUpgrades + 1) % 10 === 0 && specialUpgradeLevel === 0) {
+      console.warn('Requires Gravity Well upgrade in Sci-Fi realm to unlock.');
+      return;
+    }
+
     setGameState(prev => {
       if (prev.purchasedUpgrades.includes(upgradeId)) {
         return prev; // already purchased

--- a/src/components/scifi/Asteroid.tsx
+++ b/src/components/scifi/Asteroid.tsx
@@ -1,8 +1,8 @@
 
-import React, { useRef } from 'react';
+import React, { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Vector3, Group } from 'three';
-import { Html, useFBX } from '@react-three/drei';
+import { Html, useFBX, useGLTF } from '@react-three/drei';
 import { Progress } from '../ui/progress';
 import { assetPath } from '../../lib/assetPath';
 
@@ -20,7 +20,12 @@ export const Asteroid: React.FC<AsteroidProps> = ({
   onReachTarget
 }) => {
   const group = useRef<Group>(null);
+
   const fbx = useFBX(assetPath('assets/asteroid_01.fbx'));
+  const { scene: glbScene } = useGLTF(assetPath('assets/asteroid_pack_01.glb'));
+
+  const randomModel = useMemo(() => (Math.random() < 0.5 ? 'fbx' : 'glb'), []);
+  const randomScale = useMemo(() => Math.random() * 0.004 + 0.002, []);
 
   useFrame(() => {
     if (group.current) {
@@ -36,7 +41,10 @@ export const Asteroid: React.FC<AsteroidProps> = ({
 
   return (
     <group ref={group} position={position}>
-      <primitive object={fbx.clone()} scale={0.003} />
+      <primitive
+        object={randomModel === 'fbx' ? fbx.clone() : glbScene.clone()}
+        scale={randomScale}
+      />
       <Html position={[0, 1, 0]} center style={{ pointerEvents: 'none' }} transform distanceFactor={8}>
         <div className="w-12">
           <Progress


### PR DESCRIPTION
## Summary
- scale scifi asteroids randomly using two different models
- allow passing purchased upgrade count through MapSkillTreeView
- increase enemy spawns based on upgrades purchased
- require the `Gravity Well` upgrade for every 10th hybrid upgrade

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862bf8406e4832e86c0f9c9fb1d659d