### PR TITLE
Add sci-fi upgrade menu support

### DIFF
--- a/src/components/GameEngine.tsx
+++ b/src/components/GameEngine.tsx
@@ -12,6 +12,7 @@ import { JourneyTracker } from './JourneyTracker';
 import { WeaponUpgradeSystem } from './WeaponUpgradeSystem';
 import { ScifiWeaponUpgradeSystem } from './ScifiWeaponUpgradeSystem';
 import { CrossRealmUpgradeSystem } from './CrossRealmUpgradeSystem';
+import { useUpgradeSystem } from '../hooks/useUpgradeSystem';
 import { useGameStateManager, fantasyBuildings, scifiBuildings } from './GameStateManager';
 import { useGameLoopManager } from './GameLoopManager';
 import { useUpgradeManagers } from './UpgradeManagers';
@@ -104,6 +105,12 @@ const GameEngine: React.FC = () => {
     currentRealm,
     crossRealmUpgradesWithLevels
   });
+
+  const {
+    purchaseScifiUpgrade,
+    purchaseFantasyUpgrade,
+    getFantasyUpgradeCount
+  } = useUpgradeSystem({ gameState: stableGameState, setGameState });
 
   // Memoize all handlers to prevent re-renders
   const handlePlayerPositionUpdate = useCallback((position: { x: number; y: number; z: number }) => {
@@ -284,6 +291,8 @@ const GameEngine: React.FC = () => {
         currency={currentRealm === 'fantasy' ? stableGameState.mana : stableGameState.energyCredits}
         gameState={stableGameState}
         onPurchaseUpgrade={purchaseUpgrade}
+        onPurchaseScifiUpgrade={purchaseScifiUpgrade}
+        onPurchaseFantasyUpgrade={purchaseFantasyUpgrade}
         isTransitioning={isTransitioning}
         showTapEffect={showTapEffect}
         onTapEffectComplete={handleTapEffectComplete}

--- a/src/components/MapSkillTreeView.tsx
+++ b/src/components/MapSkillTreeView.tsx
@@ -16,6 +16,8 @@ interface MapSkillTreeViewProps {
   isTransitioning?: boolean;
   gameState: any;
   onPurchaseUpgrade: (upgradeId: string) => void;
+  onPurchaseScifiUpgrade: (upgradeId: string) => void;
+  onPurchaseFantasyUpgrade: (upgradeId: string) => void;
   showTapEffect?: boolean;
   onTapEffectComplete?: () => void;
   onPlayerPositionUpdate?: (position: { x: number; y: number; z: number }) => void;
@@ -37,6 +39,8 @@ export const MapSkillTreeView: React.FC<MapSkillTreeViewProps> = ({
   isTransitioning = false,
   gameState,
   onPurchaseUpgrade,
+  onPurchaseScifiUpgrade,
+  onPurchaseFantasyUpgrade,
   showTapEffect = false,
   onTapEffectComplete,
   onPlayerPositionUpdate,
@@ -64,24 +68,28 @@ export const MapSkillTreeView: React.FC<MapSkillTreeViewProps> = ({
 
   // Handlers
   const handleUpgradeClick = useCallback((upgradeId: string) => {
-    setSelectedUpgrade(upgradeId);
-  }, []);
+    if (realm === 'scifi') {
+      setSelectedScifiUpgrade(upgradeId);
+    } else if (realm === 'fantasy') {
+      setSelectedFantasyUpgrade(upgradeId);
+    } else {
+      setSelectedUpgrade(upgradeId);
+    }
+  }, [realm]);
 
   const handle3DUpgradeClick = useCallback((upgradeName: string) => {
     setSelected3DUpgrade(upgradeName);
   }, []);
 
   const handleScifiUpgradePurchase = useCallback((upgradeId: string) => {
-    // Handle sci-fi upgrade purchase and check for nexus shard earning
-    onPurchaseUpgrade(upgradeId);
+    onPurchaseScifiUpgrade(upgradeId);
     setSelectedScifiUpgrade(null);
-  }, [onPurchaseUpgrade]);
+  }, [onPurchaseScifiUpgrade]);
 
   const handleFantasyUpgradePurchase = useCallback((upgradeId: string) => {
-    // Handle fantasy upgrade purchase and check for nexus shard earning
-    onPurchaseUpgrade(upgradeId);
+    onPurchaseFantasyUpgrade(upgradeId);
     setSelectedFantasyUpgrade(null);
-  }, [onPurchaseUpgrade]);
+  }, [onPurchaseFantasyUpgrade]);
 
   const handleNexusShardUpgradePurchase = useCallback((upgradeId: string) => {
     console.log('Purchasing nexus shard upgrade:', upgradeId);


### PR DESCRIPTION
## Summary
- allow MapSkillTreeView to open Sci‑Fi and Fantasy upgrade menus
- hook GameEngine into new upgrade purchasing logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cff28d98832ea04c2370d2e9b0df