### PR TITLE
Replace floating scifi polygons

### DIFF
--- a/src/components/Scene3D.tsx
+++ b/src/components/Scene3D.tsx
@@ -167,7 +167,6 @@ export const Scene3D: React.FC<Scene3DProps> = React.memo(({
                 purchasedUpgrades={gameState.purchasedUpgrades || []}
               />
               <ScifiUpgradeAsteroidSystem
-                energyCredits={gameState.energyCredits || 0}
                 onUpgradeClick={setSelectedUpgrade}
                 purchasedUpgrades={gameState.purchasedUpgrades || []}
               />

--- a/src/components/scifi/ScifiUpgradeAsteroidSystem.tsx
+++ b/src/components/scifi/ScifiUpgradeAsteroidSystem.tsx
@@ -1,15 +1,14 @@
-import React, { useMemo, useState } from 'react';
-import { Vector3 } from 'three';
-import { Asteroid } from './Asteroid';
+import React, { useMemo, useRef } from 'react';
+import { Vector3, Group } from 'three';
+import { useThree, useFrame } from '@react-three/fiber';
+import { ScifiUpgradeOrb } from './ScifiUpgradeOrb';
 
 interface ScifiUpgradeAsteroidSystemProps {
-  energyCredits: number;
   onUpgradeClick: (upgradeId: string) => void;
   purchasedUpgrades: string[];
 }
 
 export const ScifiUpgradeAsteroidSystem: React.FC<ScifiUpgradeAsteroidSystemProps> = ({
-  energyCredits,
   onUpgradeClick,
   purchasedUpgrades
 }) => {
@@ -35,21 +34,27 @@ export const ScifiUpgradeAsteroidSystem: React.FC<ScifiUpgradeAsteroidSystemProp
     return positions;
   }, []);
 
+  const groupRef = useRef<Group>(null);
+  const { camera } = useThree();
+
+  useFrame(() => {
+    if (groupRef.current) {
+      groupRef.current.position.y = camera.position.y * 2;
+    }
+  });
+
   return (
-    <>
-      {upgradePositions.map(({ id, position }, index) => (
+    <group ref={groupRef}>
+      {upgradePositions.map(({ id, position }) => (
         !purchasedUpgrades.includes(id) && (
-          <Asteroid
+          <ScifiUpgradeOrb
             key={id}
+            id={id}
             position={position}
-            health={5}
-            isUpgrade={true}
-            upgradeId={id}
-            onUpgradeClick={onUpgradeClick}
-            upgradeIndex={index} // Add index for visual variety
+            onClick={() => onUpgradeClick(id)}
           />
         )
       ))}
-    </>
+    </group>
   );
 };


### PR DESCRIPTION
## Summary
- update ScifiUpgradeAsteroidSystem to show `ScifiUpgradeOrb`s instead of grey asteroid polygons
- move the orbs upward in sync with camera scroll
- use the updated system in `Scene3D`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68641a322270832ea8391af8c688e142