### PR TITLE
Improve map editor functions

### DIFF
--- a/src/components/GameLoopManager.tsx
+++ b/src/components/GameLoopManager.tsx
@@ -1,5 +1,6 @@
 
 import { useEffect, useRef } from 'react';
+import { useMapEditorStore } from '../stores/useMapEditorStore';
 import { useBuffSystem } from './CrossRealmBuffSystem';
 import { enhancedHybridUpgrades } from '../data/EnhancedHybridUpgrades';
 import { GameState, fantasyBuildings, scifiBuildings } from './GameStateManager';
@@ -24,9 +25,11 @@ export const useGameLoopManager = ({
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const buffSystem = useBuffSystem(stableFantasyBuildings, stableScifiBuildings);
   const purchasedUpgradesCount = stablePurchasedUpgrades.length;
+  const isEditorActive = useMapEditorStore((state) => state.isEditorActive);
 
   // Game loop - now includes auto mana generation
   useEffect(() => {
+    if (isEditorActive) return;
     intervalRef.current = setInterval(() => {
       setGameState(prev => {
         const deltaTime = 0.1; // 100ms intervals
@@ -47,10 +50,11 @@ export const useGameLoopManager = ({
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
-  }, [setGameState]);
+  }, [setGameState, isEditorActive]);
 
   // Enhanced production calculation with cross-realm upgrades
   useEffect(() => {
+    if (isEditorActive) return;
     let manaRate = 0;
     let energyRate = 0;
     let manaPerKill = 5;
@@ -110,7 +114,7 @@ export const useGameLoopManager = ({
       energyPerSecond: energyRate * scifiBonus * globalMultiplier,
       manaPerKill,
     }));
-  }, [stableFantasyBuildings, stableScifiBuildings, purchasedUpgradesCount, buffSystem, crossRealmUpgradesWithLevels, setGameState]);
+  }, [stableFantasyBuildings, stableScifiBuildings, purchasedUpgradesCount, buffSystem, crossRealmUpgradesWithLevels, setGameState, isEditorActive]);
 
   return { buffSystem };
 };

--- a/src/components/MapEditor/MapEditorElementPalette.tsx
+++ b/src/components/MapEditor/MapEditorElementPalette.tsx
@@ -36,7 +36,12 @@ const elementTypes: ElementType[] = [
 ];
 
 export const MapEditorElementPalette: React.FC<{ realm: 'fantasy' | 'scifi' }> = ({ realm }) => {
-  const { selectedElementType, setSelectedElementType, isEditorActive } = useMapEditorStore();
+  const {
+    selectedElementType,
+    setSelectedElementType,
+    isEditorActive,
+    setSelectedTool
+  } = useMapEditorStore();
 
   if (!isEditorActive) return null;
 
@@ -74,7 +79,10 @@ export const MapEditorElementPalette: React.FC<{ realm: 'fantasy' | 'scifi' }> =
                     key={element.id}
                     size="sm"
                     variant={selectedElementType === element.id ? 'default' : 'ghost'}
-                    onClick={() => setSelectedElementType(element.id)}
+                    onClick={() => {
+                      setSelectedElementType(element.id);
+                      setSelectedTool('place');
+                    }}
                     className="h-12 flex flex-col justify-center p-1 text-xs"
                   >
                     <div className="w-6 h-6 bg-muted rounded mb-1" />

--- a/src/hooks/useAutoEnergySystem.ts
+++ b/src/hooks/useAutoEnergySystem.ts
@@ -1,6 +1,7 @@
 
 import { useEffect, useCallback } from 'react';
 import { useAutoClickerStore } from '@/stores/useAutoClickerStore';
+import { useMapEditorStore } from '@/stores/useMapEditorStore';
 
 interface UseAutoEnergySystemProps {
   onAddEnergy: (amount: number) => void;
@@ -8,6 +9,7 @@ interface UseAutoEnergySystemProps {
 
 export const useAutoEnergySystem = ({ onAddEnergy }: UseAutoEnergySystemProps) => {
   const manaPerSecond = useAutoClickerStore((state) => state.manaPerSecond);
+  const isEditorActive = useMapEditorStore((state) => state.isEditorActive);
 
   const createFloatingEnergyText = useCallback((amount: number) => {
     const energyDisplay = document.querySelector('[data-energy-display]');
@@ -36,7 +38,7 @@ export const useAutoEnergySystem = ({ onAddEnergy }: UseAutoEnergySystemProps) =
   }, []);
 
   useEffect(() => {
-    if (manaPerSecond <= 0) return;
+    if (isEditorActive || manaPerSecond <= 0) return;
 
     const interval = setInterval(() => {
       onAddEnergy(manaPerSecond);
@@ -44,5 +46,5 @@ export const useAutoEnergySystem = ({ onAddEnergy }: UseAutoEnergySystemProps) =
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [manaPerSecond, onAddEnergy, createFloatingEnergyText]);
+  }, [manaPerSecond, onAddEnergy, createFloatingEnergyText, isEditorActive]);
 };

--- a/src/hooks/useAutoManaSystem.ts
+++ b/src/hooks/useAutoManaSystem.ts
@@ -1,6 +1,7 @@
 
 import { useEffect, useCallback } from 'react';
 import { useAutoClickerStore } from '@/stores/useAutoClickerStore';
+import { useMapEditorStore } from '@/stores/useMapEditorStore';
 
 interface UseAutoManaSystemProps {
   onAddMana: (amount: number) => void;
@@ -8,6 +9,7 @@ interface UseAutoManaSystemProps {
 
 export const useAutoManaSystem = ({ onAddMana }: UseAutoManaSystemProps) => {
   const manaPerSecond = useAutoClickerStore((state) => state.manaPerSecond);
+  const isEditorActive = useMapEditorStore((state) => state.isEditorActive);
 
   const createFloatingManaText = useCallback((amount: number) => {
     const manaDisplay = document.querySelector('[data-mana-display]');
@@ -36,7 +38,7 @@ export const useAutoManaSystem = ({ onAddMana }: UseAutoManaSystemProps) => {
   }, []);
 
   useEffect(() => {
-    if (manaPerSecond <= 0) return;
+    if (isEditorActive || manaPerSecond <= 0) return;
 
     const interval = setInterval(() => {
       onAddMana(manaPerSecond);
@@ -44,5 +46,5 @@ export const useAutoManaSystem = ({ onAddMana }: UseAutoManaSystemProps) => {
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [manaPerSecond, onAddMana, createFloatingManaText]);
+  }, [manaPerSecond, onAddMana, createFloatingManaText, isEditorActive]);
 };


### PR DESCRIPTION
## Summary
- ensure the map editor palette sets the proper tool when picking an element
- pause core game loop and auto resource generation while editing
- stop game loops inside map editor mode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643800d750832e86c560991b42b80b