### PR TITLE
Fix map editor blank screen

### DIFF
--- a/src/components/GameEngine.tsx
+++ b/src/components/GameEngine.tsx
@@ -282,17 +282,16 @@ const GameEngine: React.FC = () => {
         />
       )}
 
-      {/* Main Game Area - disabled in map editor */}
-      {!isEditorActive && (
-        <div className="absolute inset-0 pt-12 pb-32">
-          {/* Main game view without overlays */}
-          <MapSkillTreeView
-            realm={currentRealm}
-            buildings={currentRealm === 'fantasy' ? stableGameState.fantasyBuildings : stableGameState.scifiBuildings}
-            manaPerSecond={stableGameState.manaPerSecond}
-            energyPerSecond={stableGameState.energyPerSecond}
-            onBuyBuilding={(buildingId) => buyBuilding(buildingId, currentRealm === 'fantasy')}
-            buildingData={currentRealm === 'fantasy' ? fantasyBuildings : scifiBuildings}
+      {/* Main Game Area - also used for map editor */}
+      <div className="absolute inset-0 pt-12 pb-32">
+        {/* Main game view without overlays */}
+        <MapSkillTreeView
+          realm={currentRealm}
+          buildings={currentRealm === 'fantasy' ? stableGameState.fantasyBuildings : stableGameState.scifiBuildings}
+          manaPerSecond={stableGameState.manaPerSecond}
+          energyPerSecond={stableGameState.energyPerSecond}
+          onBuyBuilding={(buildingId) => buyBuilding(buildingId, currentRealm === 'fantasy')}
+          buildingData={currentRealm === 'fantasy' ? fantasyBuildings : scifiBuildings}
           currency={currentRealm === 'fantasy' ? stableGameState.mana : stableGameState.energyCredits}
           gameState={stableGameState}
           onPurchaseUpgrade={purchaseUpgrade}
@@ -308,8 +307,7 @@ const GameEngine: React.FC = () => {
           weaponDamage={currentRealm === 'fantasy' ? weaponStats.damage : scifiWeaponStats.damage}
           upgradesPurchased={stableGameState.purchasedUpgrades.length}
         />
-        </div>
-      )}
+      </div>
 
         {/* UI Elements disabled in map editor */}
         {!isEditorActive && (

--- a/src/components/SceneRenderer.tsx
+++ b/src/components/SceneRenderer.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Scene3D } from './Scene3D';
 import { Fantasy3DUpgradeWorld } from './Fantasy3DUpgradeWorld';
+import { useMapEditorStore } from '../stores/useMapEditorStore';
 
 interface SceneRendererProps {
   realm: 'fantasy' | 'scifi';
@@ -34,9 +35,22 @@ export const SceneRenderer: React.FC<SceneRendererProps> = ({
   weaponDamage,
   upgradesPurchased
 }) => {
+  const { isEditorActive } = useMapEditorStore();
+
   return (
     <>
-      {realm === 'fantasy' ? (
+      {isEditorActive ? (
+        <Scene3D
+          key="editor-scene"
+          realm={realm}
+          gameState={gameState}
+          onUpgradeClick={onUpgradeClick}
+          isTransitioning={isTransitioning}
+          showTapEffect={showTapEffect}
+          onTapEffectComplete={onTapEffectComplete}
+          onMeteorDestroyed={onMeteorDestroyed}
+        />
+      ) : realm === 'fantasy' ? (
         <Fantasy3DUpgradeWorld
           key="fantasy-world"
           onUpgradeClick={on3DUpgradeClick}


### PR DESCRIPTION
## Summary
- overlay map editor on current scene rather than switching screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68644228bd04832e8897f93edf822f5e