### PR TITLE
Add nexus world modal with shard mechanics

### DIFF
--- a/src/components/GameEngine.tsx
+++ b/src/components/GameEngine.tsx
@@ -25,6 +25,8 @@ import { ScifiAutoClickerUpgradeSystem } from './ScifiAutoClickerUpgradeSystem';
 import { CollisionProvider } from '@/lib/CollisionContext';
 import { MapEditorToolbar } from './MapEditor/MapEditorToolbar';
 import { useMapEditorStore } from '../stores/useMapEditorStore';
+import { NexusWorldModal } from './NexusWorldModal';
+import { nexusShardUpgrades } from '../data/NexusShardUpgrades';
 
 const GameEngine: React.FC = () => {
   const { isEditorActive } = useMapEditorStore();
@@ -61,6 +63,7 @@ const GameEngine: React.FC = () => {
   } = useUIStateManager(gameState);
 
   const [enemyCount, setEnemyCount] = useState(0);
+  const [showNexusWorld, setShowNexusWorld] = useState(false);
 
   // Create stable references to prevent infinite re-renders
   const stablePlayerPosition = useMemo(() => ({
@@ -129,6 +132,10 @@ const GameEngine: React.FC = () => {
       ...prev,
       mana: prev.mana + prev.manaPerKill,
       enemiesKilled: prev.enemiesKilled + 1,
+      nexusShards:
+        (prev.enemiesKilled + 1) % 50 === 0
+          ? prev.nexusShards + 1
+          : prev.nexusShards,
     }));
   }, [setGameState]);
 
@@ -251,6 +258,30 @@ const GameEngine: React.FC = () => {
     }));
   }, [setGameState]);
 
+  const handlePurchaseNexusShardUpgrade = useCallback((upgradeId: string) => {
+    const upgrade = nexusShardUpgrades.find(u => u.id === upgradeId);
+    if (!upgrade) return;
+    if (gameState.nexusShards < upgrade.cost) return;
+    if (gameState.purchasedUpgrades.includes(upgradeId)) return;
+
+    setGameState(prev => ({
+      ...prev,
+      nexusShards: prev.nexusShards - upgrade.cost,
+      purchasedUpgrades: [...prev.purchasedUpgrades, upgradeId]
+    }));
+  }, [gameState.nexusShards, gameState.purchasedUpgrades, setGameState]);
+
+  const handleBuyNexusShards = useCallback((amount: number) => {
+    const cost = amount * 100;
+    if (gameState.mana >= cost) {
+      setGameState(prev => ({
+        ...prev,
+        mana: prev.mana - cost,
+        nexusShards: prev.nexusShards + amount
+      }));
+    }
+  }, [gameState.mana, setGameState]);
+
   return (
     <CollisionProvider>
     <div className={`h-[667px] w-[375px] relative overflow-hidden bg-black ${false ? 'animate-pulse bg-red-900/20' : ''}`}>
@@ -343,11 +374,21 @@ const GameEngine: React.FC = () => {
 
             {/* Cross-Realm Upgrades Button */}
             <div className="absolute top-16 left-4 z-30">
-              <Button 
+              <Button
                 onClick={handleShowCrossRealmUpgrades}
                 className="h-10 w-10 rounded-xl bg-gradient-to-r from-indigo-500/95 to-purple-500/95 hover:from-indigo-600/95 hover:to-purple-600/95 backdrop-blur-xl border border-indigo-400/70 transition-all duration-300 font-bold shadow-lg shadow-indigo-500/30 p-0"
               >
                 🏰
+              </Button>
+            </div>
+
+            {/* Nexus World Button */}
+            <div className="absolute top-16 left-20 z-30">
+              <Button
+                onClick={() => setShowNexusWorld(true)}
+                className="h-10 w-10 rounded-xl bg-gradient-to-r from-yellow-600/95 to-pink-600/95 hover:from-yellow-700/95 hover:to-pink-700/95 backdrop-blur-xl border border-yellow-400/70 transition-all duration-300 font-bold shadow-lg shadow-yellow-500/30 p-0"
+              >
+                💠
               </Button>
             </div>
           </>
@@ -443,6 +484,18 @@ const GameEngine: React.FC = () => {
                 </div>
               </div>
             </div>
+          )}
+
+          {/* Nexus World Modal */}
+          {showNexusWorld && (
+            <NexusWorldModal
+              isOpen={showNexusWorld}
+              nexusShards={stableGameState.nexusShards}
+              purchasedUpgrades={stableGameState.purchasedUpgrades}
+              onPurchaseUpgrade={handlePurchaseNexusShardUpgrade}
+              onBuyShards={handleBuyNexusShards}
+              onClose={() => setShowNexusWorld(false)}
+            />
           )}
         </>
       )}

--- a/src/components/NexusWorldModal.tsx
+++ b/src/components/NexusWorldModal.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Canvas } from '@react-three/fiber';
+import { Button } from '@/components/ui/button';
+import { NexusShardShop } from './NexusShardShop';
+import { nexusShardUpgrades, NexusShardUpgrade } from '../data/NexusShardUpgrades';
+
+interface NexusWorldModalProps {
+  isOpen: boolean;
+  nexusShards: number;
+  purchasedUpgrades: string[];
+  onPurchaseUpgrade: (upgradeId: string) => void;
+  onBuyShards: (amount: number) => void;
+  onClose: () => void;
+}
+
+export const NexusWorldModal: React.FC<NexusWorldModalProps> = ({
+  isOpen,
+  nexusShards,
+  purchasedUpgrades,
+  onPurchaseUpgrade,
+  onBuyShards,
+  onClose
+}) => {
+  if (!isOpen) return null;
+
+  const upgrades: NexusShardUpgrade[] = nexusShardUpgrades.map(u => ({
+    ...u,
+    purchased: purchasedUpgrades.includes(u.id)
+  }));
+
+  return (
+    <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="w-full max-w-md space-y-4">
+        <div className="w-full h-60 rounded-lg overflow-hidden bg-gray-900">
+          <Canvas camera={{ position: [0, 2, 5], fov: 60 }}>
+            <ambientLight intensity={0.7} />
+            <pointLight position={[5, 5, 5]} />
+            <mesh rotation={[0.5, 0.5, 0]}>
+              <boxGeometry args={[2, 2, 2]} />
+              <meshStandardMaterial color="#a855f7" />
+            </mesh>
+          </Canvas>
+        </div>
+        <div className="flex justify-center gap-2">
+          <Button size="sm" onClick={() => onBuyShards(1)}>
+            Buy 1 Shard (100 Mana)
+          </Button>
+          <Button size="sm" onClick={() => onBuyShards(10)}>
+            Buy 10 Shards (1000 Mana)
+          </Button>
+        </div>
+        <NexusShardShop
+          upgrades={upgrades}
+          nexusShards={nexusShards}
+          hasFantasySpecial={true}
+          hasScifiSpecial={true}
+          onPurchase={onPurchaseUpgrade}
+          onClose={onClose}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default NexusWorldModal;


### PR DESCRIPTION
## Summary
- introduce `NexusWorldModal` with simple 3D scene and shard shop
- update GameEngine to open nexus world, purchase shards and upgrades
- drop a nexus shard every 50 enemy kills

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68648170f3ec832e9989fe9fa77664b4