### PR TITLE
Simplify Nexus world load

### DIFF
--- a/src/components/NexusGround.tsx
+++ b/src/components/NexusGround.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
-import { Plane } from '@react-three/drei';
-import * as THREE from 'three';
+import React from "react";
+import { Plane } from "@react-three/drei";
+import * as THREE from "three";
 
 interface NexusGroundProps {
   size?: number;
   color?: string;
 }
 
-export const NexusGround: React.FC<NexusGroundProps> = ({ 
-  size = 100, 
-  color = "#1a1a2e" 
+export const NexusGround: React.FC<NexusGroundProps> = ({
+  size = 100,
+  color = "#1a1a2e",
 }) => {
   return (
     <group>
@@ -19,28 +19,23 @@ export const NexusGround: React.FC<NexusGroundProps> = ({
         rotation={[-Math.PI / 2, 0, 0]}
         position={[0, -0.5, 0]}
       >
-        <meshStandardMaterial 
-          color={color} 
-          roughness={0.8}
-          metalness={0.1}
-        />
+        <meshStandardMaterial color={color} roughness={0.8} metalness={0.1} />
       </Plane>
-      
+
       {/* Grid lines for visual reference */}
       <primitive
         object={new THREE.GridHelper(size, 20, "#333344", "#222233")}
         position={[0, -0.45, 0]}
       />
-      
+
       {/* Subtle ambient lighting for the ground */}
       <ambientLight intensity={0.3} />
-      <directionalLight 
-        position={[10, 10, 5]} 
+      <directionalLight
+        position={[10, 10, 5]}
         intensity={0.8}
         castShadow
         shadow-mapSize-width={2048}
         shadow-mapSize-height={2048}
       />
     </group>
-  );
-};
+  );};

--- a/src/components/SimpleNexusWorld.tsx
+++ b/src/components/SimpleNexusWorld.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { Canvas } from '@react-three/fiber';
-import { NexusGround } from './NexusGround';
-import { NexusFirstPersonController } from './NexusFirstPersonController';
+import React from "react";
+import { Canvas } from "@react-three/fiber";
+import { NexusGround } from "./NexusGround";
+import { NexusFirstPersonController } from "./NexusFirstPersonController";
 
 /**
  * A lightweight 3D world containing only a floor and basic lights.
@@ -11,8 +11,8 @@ import { NexusFirstPersonController } from './NexusFirstPersonController';
 export const SimpleNexusWorld: React.FC = () => (
   <Canvas
     camera={{ position: [0, 2, 5], fov: 60 }}
-    style={{ height: '100%', width: '100%' }}
-    onCreated={({ gl }) => gl.setClearColor('#000000')}
+    style={{ height: "100%", width: "100%" }}
+    onCreated={({ gl }) => gl.setClearColor("#000000")}
   >
     <ambientLight intensity={0.3} />
     <directionalLight position={[5, 10, 5]} intensity={0.5} />
@@ -20,4 +20,3 @@ export const SimpleNexusWorld: React.FC = () => (
     <NexusFirstPersonController />
   </Canvas>
 );
-

--- a/src/components/SimpleNexusWorld.tsx
+++ b/src/components/SimpleNexusWorld.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Canvas } from '@react-three/fiber';
+import { NexusGround } from './NexusGround';
+import { NexusFirstPersonController } from './NexusFirstPersonController';
+
+/**
+ * A lightweight 3D world containing only a floor and basic lights.
+ * This is used when we want a minimal environment for testing or
+ * when the full Nexus3DWorld is too heavy to load.
+ */
+export const SimpleNexusWorld: React.FC = () => (
+  <Canvas
+    camera={{ position: [0, 2, 5], fov: 60 }}
+    style={{ height: '100%', width: '100%' }}
+    onCreated={({ gl }) => gl.setClearColor('#000000')}
+  >
+    <ambientLight intensity={0.3} />
+    <directionalLight position={[5, 10, 5]} intensity={0.5} />
+    <NexusGround />
+    <NexusFirstPersonController />
+  </Canvas>
+);
+

--- a/src/pages/NexusWorld.tsx
+++ b/src/pages/NexusWorld.tsx
@@ -1,9 +1,9 @@
-import React, { Suspense } from 'react';
-import { Button } from '@/components/ui/button';
-import { ArrowLeft, Crown } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
-import { SimpleNexusWorld } from '@/components/SimpleNexusWorld';
-import { ErrorBoundary } from '@/components/ErrorBoundary';
+import React, { Suspense } from "react";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft, Crown } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { SimpleNexusWorld } from "@/components/SimpleNexusWorld";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 interface NexusWorldProps {
   gameState?: any;
@@ -23,9 +23,8 @@ const NexusWorld: React.FC<NexusWorldProps> = ({
   const navigate = useNavigate();
 
   const handleBackToGame = () => {
-    navigate('/');
+    navigate("/");
   };
-
 
   return (
     <div className="h-full w-full relative overflow-hidden bg-black">
@@ -40,7 +39,6 @@ const NexusWorld: React.FC<NexusWorldProps> = ({
           <ArrowLeft className="w-4 h-4 mr-2" />
           Back to Game
         </Button>
-        
         <div className="text-center">
           <h1 className="text-lg font-bold text-white/90 flex items-center gap-2">
             <Crown className="text-yellow-400" size={18} />
@@ -48,16 +46,21 @@ const NexusWorld: React.FC<NexusWorldProps> = ({
             <Crown className="text-yellow-400" size={18} />
           </h1>
         </div>
-        
         <div className="w-20" /> {/* Spacer for centering */}
       </div>
 
       {/* Resource Display */}
       <div className="absolute top-14 left-2 z-50">
         <div className="bg-black/60 backdrop-blur-md rounded-lg border border-white/20 p-2 text-xs">
-          <div className="text-purple-300">Mana: {(gameState?.mana || 0).toLocaleString()}</div>
-          <div className="text-cyan-300">Energy: {(gameState?.energyCredits || 0).toLocaleString()}</div>
-          <div className="text-yellow-300">Shards: {gameState?.nexusShards || 0}</div>
+          <div className="text-purple-300">
+            Mana: {(gameState?.mana || 0).toLocaleString()}
+          </div>
+          <div className="text-cyan-300">
+            Energy: {(gameState?.energyCredits || 0).toLocaleString()}
+          </div>
+          <div className="text-yellow-300">
+            Shards: {gameState?.nexusShards || 0}
+          </div>
         </div>
       </div>
 
@@ -73,22 +76,26 @@ const NexusWorld: React.FC<NexusWorldProps> = ({
 
       {/* 3D Nexus World */}
       <div className="absolute inset-0 pt-12">
-        <ErrorBoundary fallback={
-          <div className="flex items-center justify-center h-full w-full bg-black text-white">
-            <div className="text-center">
-              <h2 className="text-xl mb-2">Loading Nexus World...</h2>
-              <p className="text-gray-400">Initializing 3D environment</p>
-            </div>
-          </div>
-        }>
-          <Suspense fallback={
+        <ErrorBoundary
+          fallback={
             <div className="flex items-center justify-center h-full w-full bg-black text-white">
               <div className="text-center">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-500 mx-auto mb-4"></div>
-                <p className="text-gray-400">Loading 3D world...</p>
+                <h2 className="text-xl mb-2">Loading Nexus World...</h2>
+                <p className="text-gray-400">Initializing 3D environment</p>
               </div>
             </div>
-          }>
+          }
+        >
+          <Suspense
+            fallback={
+              <div className="flex items-center justify-center h-full w-full bg-black text-white">
+                <div className="text-center">
+                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-500 mx-auto mb-4"></div>
+                  <p className="text-gray-400">Loading 3D world...</p>
+                </div>
+              </div>
+            }
+          >
             {/* Simplified 3D world with just a floor */}
             <SimpleNexusWorld />
           </Suspense>

--- a/src/pages/NexusWorld.tsx
+++ b/src/pages/NexusWorld.tsx
@@ -16,10 +16,10 @@ const NexusWorld: React.FC<NexusWorldProps> = ({
     nexusShards: 25, 
     manaPerSecond: 15, 
     energyPerSecond: 12,
-    convergenceCount: 3,
-    convergenceProgress: 45
+  convergenceCount: 3,
+  convergenceProgress: 45
   }
-) => {
+}) => {
   const navigate = useNavigate();
 
   const handleBackToGame = () => {

--- a/src/pages/NexusWorld.tsx
+++ b/src/pages/NexusWorld.tsx
@@ -2,12 +2,11 @@ import React, { Suspense } from 'react';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, Crown } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { Nexus3DWorld } from '@/components/Nexus3DWorld';
+import { SimpleNexusWorld } from '@/components/SimpleNexusWorld';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 
 interface NexusWorldProps {
   gameState?: any;
-  onUpgrade?: (upgradeId: string) => void;
 }
 
 const NexusWorld: React.FC<NexusWorldProps> = ({ 
@@ -19,19 +18,14 @@ const NexusWorld: React.FC<NexusWorldProps> = ({
     energyPerSecond: 12,
     convergenceCount: 3,
     convergenceProgress: 45
-  },
-  onUpgrade = () => {}
-}) => {
+  }
+) => {
   const navigate = useNavigate();
 
   const handleBackToGame = () => {
     navigate('/');
   };
 
-  const handleUpgrade = (upgradeType: string) => {
-    console.log(`Purchasing upgrade: ${upgradeType}`);
-    onUpgrade(upgradeType);
-  };
 
   return (
     <div className="h-full w-full relative overflow-hidden bg-black">
@@ -95,10 +89,8 @@ const NexusWorld: React.FC<NexusWorldProps> = ({
               </div>
             </div>
           }>
-            <Nexus3DWorld 
-              gameState={gameState}
-              onUpgrade={handleUpgrade}
-            />
+            {/* Simplified 3D world with just a floor */}
+            <SimpleNexusWorld />
           </Suspense>
         </ErrorBoundary>
       </div>

--- a/src/pages/NexusWorld.tsx
+++ b/src/pages/NexusWorld.tsx
@@ -97,5 +97,4 @@ const NexusWorld: React.FC<NexusWorldProps> = ({
     </div>
   );
 };
-
 export default NexusWorld;

--- a/src/pages/NexusWorld.tsx
+++ b/src/pages/NexusWorld.tsx
@@ -9,16 +9,16 @@ interface NexusWorldProps {
   gameState?: any;
 }
 
-const NexusWorld: React.FC<NexusWorldProps> = ({ 
-  gameState = { 
-    mana: 1000, 
-    energyCredits: 800, 
-    nexusShards: 25, 
-    manaPerSecond: 15, 
+const NexusWorld: React.FC<NexusWorldProps> = ({
+  gameState = {
+    mana: 1000,
+    energyCredits: 800,
+    nexusShards: 25,
+    manaPerSecond: 15,
     energyPerSecond: 12,
-  convergenceCount: 3,
-  convergenceProgress: 45
-  }
+    convergenceCount: 3,
+    convergenceProgress: 45,
+  },
 }) => {
   const navigate = useNavigate();
 


### PR DESCRIPTION
## Summary
- add new `SimpleNexusWorld` component with just ground and first person controls
- switch `NexusWorld` page to use the simple world

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d46d7cfe4832eb77d125328447bef