### PR TITLE
Fix Nexus world loading

### DIFF
--- a/src/pages/NexusWorld.tsx
+++ b/src/pages/NexusWorld.tsx
@@ -1,7 +1,10 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, lazy } from 'react';
 import { Crown } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { Nexus3DWorld } from '@/components/Nexus3DWorld';
+// Lazy load the heavy 3D world to avoid blocking the initial render
+const Nexus3DWorld = lazy(
+  () => import('@/components/Nexus3DWorld').then((m) => ({ default: m.Nexus3DWorld }))
+);
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { BottomActionBar } from '@/components/BottomActionBar';
 


### PR DESCRIPTION
## Summary
- lazy load `Nexus3DWorld` so heavy 3D code loads after initial render

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d57eff57c832e9a8eef9bcf414735