### PR TITLE
Refactor nexus hub world

### DIFF
--- a/src/components/NexusWorld/BackgroundElements.tsx
+++ b/src/components/NexusWorld/BackgroundElements.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Sky } from '@react-three/drei';
+
+const BackgroundElements: React.FC = () => {
+  return (
+    <group>
+      <Sky distance={450000} sunPosition={[5, 1, 8]} inclination={0} azimuth={0.25} />
+    </group>
+  );
+};
+
+export default BackgroundElements;

--- a/src/components/NexusWorld/CentralObelisk.tsx
+++ b/src/components/NexusWorld/CentralObelisk.tsx
@@ -1,0 +1,38 @@
+import React, { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Mesh } from 'three';
+
+const CentralObelisk: React.FC = () => {
+  const obeliskRef = useRef<Mesh>(null);
+  const glowRef = useRef<Mesh>(null);
+
+  useFrame((state) => {
+    const t = state.clock.getElapsedTime();
+    if (obeliskRef.current) {
+      obeliskRef.current.rotation.y = t * 0.2;
+    }
+    if (glowRef.current && (glowRef.current.material as any)) {
+      (glowRef.current.material as any).emissiveIntensity = 0.6 + Math.sin(t * 2) * 0.2;
+    }
+  });
+
+  return (
+    <group>
+      <mesh position={[0, 0.5, 0]}>
+        <cylinderGeometry args={[2, 2, 1, 12]} />
+        <meshStandardMaterial color="#7a7a7a" />
+      </mesh>
+      <mesh ref={obeliskRef} position={[0, 2.5, 0]} castShadow>
+        <cylinderGeometry args={[0.6, 0.6, 4, 8]} />
+        <meshStandardMaterial color="#a4c8ff" metalness={0.3} roughness={0.2} />
+      </mesh>
+      <mesh ref={glowRef} position={[0, 2.5, 0]}>
+        <cylinderGeometry args={[0.62, 0.62, 4.1, 8]} />
+        <meshStandardMaterial color="#80caff" emissive="#80caff" transparent opacity={0.35} />
+      </mesh>
+      <pointLight position={[0, 5, 0]} intensity={1} color="#80caff" distance={15} />
+    </group>
+  );
+};
+
+export default CentralObelisk;

--- a/src/components/NexusWorld/FenceSegment.tsx
+++ b/src/components/NexusWorld/FenceSegment.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface FenceSegmentProps {
+  position: [number, number, number];
+  rotation?: [number, number, number];
+}
+
+const FenceSegment: React.FC<FenceSegmentProps> = ({ position, rotation = [0,0,0] }) => {
+  return (
+    <mesh position={position} rotation={rotation} castShadow>
+      <boxGeometry args={[1,0.4,0.1]} />
+      <meshStandardMaterial color="#8b4513" />
+    </mesh>
+  );
+};
+
+export default FenceSegment;

--- a/src/components/NexusWorld/Nexus3DWorld.tsx
+++ b/src/components/NexusWorld/Nexus3DWorld.tsx
@@ -1,0 +1,42 @@
+import React, { Suspense, useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import CentralObelisk from './CentralObelisk';
+import VendorStall from './VendorStall';
+import SandboxGrid from './SandboxGrid';
+import FenceSegment from './FenceSegment';
+import BackgroundElements from './BackgroundElements';
+
+interface Nexus3DWorldProps {
+  onTileSelect?: (x:number,z:number) => void;
+}
+
+const Nexus3DWorld: React.FC<Nexus3DWorldProps> = ({ onTileSelect }) => {
+  const [gridSize] = useState(6);
+
+  const fencePositions = Array.from({length:16}).map((_,i)=>{
+    const angle = (i/16)*Math.PI*2;
+    const radius = gridSize/2 + 3;
+    return [Math.cos(angle)*radius,0,Math.sin(angle)*radius] as [number,number,number];
+  });
+
+  return (
+    <Canvas camera={{ position: [0, 8, 10], fov: 50 }} style={{ height: '100%', width: '100%' }} shadows>
+      <ambientLight intensity={0.6} />
+      <hemisphereLight intensity={0.6} groundColor="#ffffff" />
+      <Suspense fallback={null}>
+        <BackgroundElements />
+        <CentralObelisk />
+        <VendorStall type="magic" color="#8a2be2" position={[-4,0,0]} />
+        <VendorStall type="tech" color="#1e90ff" position={[4,0,0]} />
+        <SandboxGrid position={[0,0,4]} size={gridSize} onTileClick={(x,z)=>onTileSelect?.(x,z)} />
+        {fencePositions.map((pos,i)=> (
+          <FenceSegment key={i} position={pos} rotation={[0,(i/16)*Math.PI*2,0]} />
+        ))}
+      </Suspense>
+      <OrbitControls enablePan={false} enableZoom={false} />
+    </Canvas>
+  );
+};
+
+export default Nexus3DWorld;

--- a/src/components/NexusWorld/SandboxGrid.tsx
+++ b/src/components/NexusWorld/SandboxGrid.tsx
@@ -1,0 +1,57 @@
+import React, { useRef, useState } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Mesh } from 'three';
+
+interface SandboxGridProps {
+  position: [number, number, number];
+  size: number;
+  onTileClick: (x: number, z: number) => void;
+}
+
+const SandboxGrid: React.FC<SandboxGridProps> = ({ position, size, onTileClick }) => {
+  const [hovered, setHovered] = useState<{x:number,z:number}|null>(null);
+  const gridRef = useRef<Mesh>(null);
+  const tileSize = 1;
+  const half = Math.floor(size/2);
+
+  useFrame((state) => {
+    const t = state.clock.getElapsedTime();
+    if (gridRef.current && (gridRef.current.material as any)) {
+      (gridRef.current.material as any).opacity = 0.5 + Math.sin(t*2)*0.1;
+    }
+  });
+
+  return (
+    <group position={position}>
+      {/* base */}
+      <mesh position={[0,-0.05,0]} receiveShadow>
+        <boxGeometry args={[size+0.5,0.1,size+0.5]} />
+        <meshStandardMaterial color="#7ecf6b" />
+      </mesh>
+      {/* grid */}
+      <mesh ref={gridRef} rotation={[-Math.PI/2,0,0]} position={[0,0.001,0]}>
+        <planeGeometry args={[size,size,size,size]} />
+        <meshStandardMaterial color="#ffffff" transparent opacity={0.6} wireframe />
+      </mesh>
+      {Array.from({length:size*size}).map((_,idx)=>{
+        const x = idx%size - half;
+        const z = Math.floor(idx/size)-half;
+        const isHover = hovered?.x===x && hovered?.z===z;
+        return (
+          <mesh
+            key={`${x}-${z}`}
+            position={[x*tileSize,0.02,z*tileSize]}
+            onPointerEnter={()=>setHovered({x,z})}
+            onPointerLeave={()=>setHovered(null)}
+            onClick={()=>onTileClick(x,z)}
+          >
+            <planeGeometry args={[0.9,0.9]} />
+            <meshStandardMaterial color={isHover?"#bde5a8":"#a0d68a"} transparent opacity={0.8} />
+          </mesh>
+        );
+      })}
+    </group>
+  );
+};
+
+export default SandboxGrid;

--- a/src/components/NexusWorld/VendorStall.tsx
+++ b/src/components/NexusWorld/VendorStall.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Text } from '@react-three/drei';
+
+interface VendorStallProps {
+  type: 'magic' | 'tech';
+  position: [number, number, number];
+  color: string;
+}
+
+const VendorStall: React.FC<VendorStallProps> = ({ type, position, color }) => {
+  const label = type === 'magic' ? 'Magic Vendor' : 'Tech Vendor';
+  return (
+    <group position={position}>
+      {/* Base table */}
+      <mesh position={[0, 0.4, 0]}>
+        <boxGeometry args={[2, 0.8, 1]} />
+        <meshStandardMaterial color="#8b5a2b" />
+      </mesh>
+      {/* Roof */}
+      <mesh position={[0, 1.4, 0]}>
+        <boxGeometry args={[2.2, 0.2, 1.2]} />
+        <meshStandardMaterial color={color} />
+      </mesh>
+      {/* Support posts */}
+      {[
+        [-0.9, 0.8, -0.45],
+        [0.9, 0.8, -0.45],
+        [-0.9, 0.8, 0.45],
+        [0.9, 0.8, 0.45]
+      ].map((p, i) => (
+        <mesh key={i} position={p as [number, number, number]}>
+          <cylinderGeometry args={[0.05, 0.05, 1.2]} />
+          <meshStandardMaterial color="#654321" />
+        </mesh>
+      ))}
+      {/* Label */}
+      <Text position={[0, 1.8, 0]} fontSize={0.3} color="white" anchorX="center" anchorY="middle">
+        {label}
+      </Text>
+    </group>
+  );
+};
+
+export default VendorStall;

--- a/src/pages/NexusWorld.tsx
+++ b/src/pages/NexusWorld.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { useGameStateStore } from '@/stores/useGameStateStore';
 // Lazy load the heavy 3D world to avoid blocking the initial render
 const Nexus3DWorld = lazy(
-  () => import('@/components/Nexus3DWorld').then((m) => ({ default: m.Nexus3DWorld }))
+  () => import('@/components/NexusWorld/Nexus3DWorld').then((m) => ({ default: m.default }))
 );
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { BottomActionBar } from '@/components/BottomActionBar';
@@ -77,18 +77,7 @@ const NexusWorld: React.FC<NexusWorldProps> = ({
               </div>
             </div>
           }>
-            <Nexus3DWorld 
-              gameState={{
-                mana,
-                energyCredits, 
-                nexusShards,
-                manaPerSecond,
-                energyPerSecond,
-                convergenceCount,
-                convergenceProgress
-              }}
-              onUpgrade={handleUpgrade}
-            />
+            <Nexus3DWorld onTileSelect={(x, z) => console.log('Tile selected', x, z)} />
           </Suspense>
         </ErrorBoundary>
       </div>


### PR DESCRIPTION
## Summary
- refactor NexusWorld to load new modular world
- add bright fantasy hub components: CentralObelisk, VendorStall, SandboxGrid, FenceSegment, BackgroundElements
- implement redesigned Nexus3DWorld with these components

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875523a4000832e9eb795367073e685