### PR TITLE
Fix Nexus world loading

### DIFF
--- a/src/components/NexusWorld/Nexus3DWorld.tsx
+++ b/src/components/NexusWorld/Nexus3DWorld.tsx
@@ -13,19 +13,25 @@ const Nexus3DWorld: React.FC = () => {
   console.log('Nexus3DWorld: Starting full render');
   
   return (
-    <Canvas camera={{ position: [0, 3, 8], fov: 60 }} style={{ height: '100%', width: '100%' }} shadows>
-      <color attach="background" args={["#001122"]} />
+    <Canvas
+      camera={{ position: [0, 4, 8], fov: 55 }}
+      style={{ height: '100%', width: '100%' }}
+      shadows
+    >
+      <color attach="background" args={["#05070a"]} />
       <ambientLight intensity={0.6} />
       <directionalLight position={[5, 10, 5]} intensity={1.2} castShadow />
-      
+
       <Suspense fallback={null}>
         <Environment preset="sunset" />
         <BackgroundElements />
         <Terrain />
         <CurvedPath />
         <CentralObelisk />
-        <VendorStall type="magic" color="#8a2be2" position={[-3, 0, 2]} />
-        <VendorStall type="tech" color="#1e90ff" position={[3, 0, 2]} />
+        <group position={[0, 0, 2]}>
+          <VendorStall type="magic" color="#8a2be2" position={[-2, 0, 0]} />
+          <VendorStall type="tech" color="#1e90ff" position={[2, 0, 0]} />
+        </group>
         <FancyFence />
         <PlayerControls />
       </Suspense>

--- a/src/pages/NexusWorld.tsx
+++ b/src/pages/NexusWorld.tsx
@@ -1,11 +1,9 @@
-import React, { Suspense, lazy, useState } from 'react';
+import React, { Suspense, useState } from 'react';
 import { Crown } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useGameStateStore } from '@/stores/useGameStateStore';
-// Lazy load the heavy 3D world to avoid blocking the initial render
-const Nexus3DWorld = lazy(
-  () => import('@/components/NexusWorld/Nexus3DWorld').then((m) => ({ default: m.default }))
-);
+// Directly import the world to avoid dynamic loading issues
+import Nexus3DWorld from '@/components/NexusWorld/Nexus3DWorld';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { BottomActionBar } from '@/components/BottomActionBar';
 import { TopHUD } from '@/components/TopHUD';


### PR DESCRIPTION
## Summary
- directly import Nexus3DWorld to remove dynamic import errors
- rearrange vendor stalls and update camera in Nexus3DWorld

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687691fb9bcc832eb2da8db7df4e7b64