### PR TITLE
Improve iOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,15 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Running on iOS
+
+This project uses [Capacitor](https://capacitorjs.com/) for mobile builds. After installing dependencies and building the web assets, you can generate and run the iOS project with:
+
+```sh
+npm run build
+npx cap sync ios
+npx cap open ios
+```
+
+The last command opens the Xcode workspace where you can build and deploy the app to the iOS simulator or a connected device.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "BROWSERSLIST_IGNORE_OLD_DATA=true vite build",
     "build:dev": "BROWSERSLIST_IGNORE_OLD_DATA=true vite build --mode development",
     "lint": "eslint .",
-    "preview": "BROWSERSLIST_IGNORE_OLD_DATA=true vite preview"
+    "preview": "BROWSERSLIST_IGNORE_OLD_DATA=true vite preview",
+    "ios": "npx cap sync ios && npx cap open ios"
   },
   "dependencies": {
     "@capacitor/android": "^7.4.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { HashRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from '@/components/ui/sonner';
 import Index from './pages/Index';
@@ -13,7 +13,7 @@ const queryClient = new QueryClient();
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <Router>
+      <HashRouter>
         <IPhoneFrameMinimal>
           <Routes>
             <Route path="/" element={<Index />} />
@@ -22,7 +22,7 @@ function App() {
           </Routes>
         </IPhoneFrameMinimal>
         <Toaster />
-      </Router>
+      </HashRouter>
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Summary
- switch to `HashRouter` for better mobile compatibility
- document how to run the project on iOS
- add `ios` helper script

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6877d3f90d88832eabf1b1075118c8e3