### PR TITLE
Remove iPhone frame for responsive layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import { Toaster } from '@/components/ui/sonner';
 import Index from './pages/Index';
 import NexusWorld from './pages/NexusWorld';
 import NotFound from './pages/NotFound';
-import { iPhoneFrameMinimal as IPhoneFrameMinimal } from '@/components/iPhoneFrameMinimal';
 
 const queryClient = new QueryClient();
 
@@ -14,13 +13,11 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <HashRouter>
-        <IPhoneFrameMinimal>
-          <Routes>
-            <Route path="/" element={<Index />} />
-            <Route path="/nexus-world" element={<NexusWorld />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </IPhoneFrameMinimal>
+        <Routes>
+          <Route path="/" element={<Index />} />
+          <Route path="/nexus-world" element={<NexusWorld />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
         <Toaster />
       </HashRouter>
     </QueryClientProvider>

--- a/src/components/InventoryManager.tsx
+++ b/src/components/InventoryManager.tsx
@@ -37,8 +37,8 @@ export const InventoryManager: React.FC = () => {
 
   return (
     <>
-      {/* Hotbar - positioned relative to phone screen */}
-      <div className="absolute bottom-16 left-1/2 transform -translate-x-1/2 z-50">
+      {/* Hotbar - centered near the bottom */}
+      <div className="absolute bottom-20 md:bottom-16 left-1/2 transform -translate-x-1/2 z-50">
         <MinecraftHotbar
           selectedSlot={selectedHotbarSlot}
           onSlotSelect={handleHotbarSlotSelect}
@@ -52,8 +52,8 @@ export const InventoryManager: React.FC = () => {
         onClose={() => setIsInventoryOpen(false)}
       />
 
-      {/* Inventory Toggle Button - positioned relative to phone screen */}
-      <div className="absolute bottom-2 right-2 z-50">
+      {/* Inventory Toggle Button - bottom right corner */}
+      <div className="absolute bottom-4 right-4 z-50">
         <button
           onClick={toggleInventory}
           className="w-8 h-8 bg-stone-800/80 border border-stone-600 rounded-md flex items-center justify-center text-white hover:bg-stone-700/80 transition-colors text-xs"

--- a/src/components/Scene3D.tsx
+++ b/src/components/Scene3D.tsx
@@ -138,7 +138,7 @@ export const Scene3D: React.FC<Scene3DProps> = React.memo(({
         className={`transition-all duration-500 ${isTransitioning ? 'opacity-70 blur-sm' : 'opacity-100'}`}
         dpr={[1, 1]}
         performance={{ min: 0.8 }}
-        style={{ width: '375px', height: '667px' }}
+        style={{ width: '100%', height: '100%' }}
         gl={{ 
           antialias: false, 
           alpha: false,
@@ -156,7 +156,6 @@ export const Scene3D: React.FC<Scene3DProps> = React.memo(({
             fov={65}
             near={0.01}
             far={500}
-            aspect={375 / 667}
             onUpdate={(cam) => cam.updateProjectionMatrix()}
           />
 

--- a/src/index.css
+++ b/src/index.css
@@ -236,13 +236,6 @@ html, body, #root, canvas {
     }
   }
 
-  .iphone-safe-top {
-    padding-top: max(16px, env(safe-area-inset-top));
-  }
-  
-  .iphone-safe-bottom {
-    padding-bottom: max(16px, env(safe-area-inset-bottom));
-  }
 
   .border-3 {
     border-width: 3px;


### PR DESCRIPTION
## Summary
- remove the iPhone frame wrapper
- clean up inventory manager positioning
- make the 3D scene canvas fill the screen
- drop unused iPhone safe-area CSS

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6877ff222978832ea2dcd53931d76c07