### PR TITLE
Add mobile joystick controls and faster scifi scroll

### DIFF
--- a/src/components/Enhanced360Controller.tsx
+++ b/src/components/Enhanced360Controller.tsx
@@ -84,9 +84,9 @@ export const Enhanced360Controller: React.FC<Enhanced360ControllerProps> = ({
         const deltaX = event.touches[0].clientX - lastX.current;
         const deltaY = event.touches[0].clientY - lastY.current;
         
-        // Vertical movement - 4x faster for fantasy realm, 3x faster for scifi realm
-        const fantasySensitivityMultiplier = realm === 'fantasy' ? 4.0 : 3.0;
-        const moveAmountY = deltaY * sensitivity * 0.01 * fantasySensitivityMultiplier;
+        // Vertical movement - 4x faster for fantasy realm, 6x faster for scifi realm
+        const verticalSensitivityMultiplier = realm === 'fantasy' ? 4.0 : 6.0;
+        const moveAmountY = deltaY * sensitivity * 0.01 * verticalSensitivityMultiplier;
         targetY.current = Math.max(minY, Math.min(maxY, targetY.current - moveAmountY));
         
         // Circular movement around center point (for scifi realm)
@@ -136,9 +136,9 @@ export const Enhanced360Controller: React.FC<Enhanced360ControllerProps> = ({
       const deltaX = event.clientX - lastX.current;
       const deltaY = event.clientY - lastY.current;
       
-      // Vertical movement - 4x faster for fantasy realm, 3x faster for scifi realm
-      const fantasySensitivityMultiplier = realm === 'fantasy' ? 4.0 : 3.0;
-      const moveAmountY = deltaY * sensitivity * 0.01 * fantasySensitivityMultiplier;
+      // Vertical movement - 4x faster for fantasy realm, 6x faster for scifi realm
+      const verticalSensitivityMultiplier = realm === 'fantasy' ? 4.0 : 6.0;
+      const moveAmountY = deltaY * sensitivity * 0.01 * verticalSensitivityMultiplier;
       targetY.current = Math.max(minY, Math.min(maxY, targetY.current - moveAmountY));
       
       // Circular movement around center point (for scifi realm)

--- a/src/components/FirstPersonController.tsx
+++ b/src/components/FirstPersonController.tsx
@@ -1,5 +1,7 @@
 
 import React, { useRef, useEffect } from 'react';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { VirtualJoystick } from './VirtualJoystick';
 import { useFrame, useThree } from '@react-three/fiber';
 import { Vector3 } from 'three';
 
@@ -15,6 +17,7 @@ export const FirstPersonController: React.FC<FirstPersonControllerProps> = ({
   canMoveForward
 }) => {
   const { camera } = useThree();
+  const isMobile = useIsMobile();
   const targetPosition = useRef(new Vector3(...position));
   const moveSpeed = useRef(0);
   const moveDirection = useRef(0);
@@ -24,6 +27,20 @@ export const FirstPersonController: React.FC<FirstPersonControllerProps> = ({
   const yawAngle = useRef(0);
   const isMouseDown = useRef(false);
   const lastMouseX = useRef(0);
+
+  const handleJoystickMove = (dx: number, dy: number) => {
+    if (Math.abs(dy) > 0.1) {
+      moveSpeed.current = Math.min(7, Math.abs(dy) * 7);
+      moveDirection.current = dy < 0 ? 1 : -1;
+    } else {
+      moveSpeed.current = 0;
+      moveDirection.current = 0;
+    }
+
+    if (Math.abs(dx) > 0.05) {
+      yawAngle.current += dx * 0.05;
+    }
+  };
 
   // Handle keyboard input
   useEffect(() => {
@@ -104,53 +121,42 @@ export const FirstPersonController: React.FC<FirstPersonControllerProps> = ({
     };
   }, []);
 
-  // Touch controls for mobile
+  // Touch look controls for mobile
   useEffect(() => {
+    if (!isMobile) return;
     const handleTouchStart = (event: TouchEvent) => {
       if (event.touches.length === 1) {
-        const touch = event.touches[0];
-        const rect = (event.target as HTMLElement).getBoundingClientRect();
-        const y = touch.clientY - rect.top;
-        const x = touch.clientX - rect.left;
-        
-        // Movement in upper portion (forward)
-        if (y < rect.height * 0.3 && canMoveForward) {
-          moveSpeed.current = 7; // Increased speed from 5 to 7
-          moveDirection.current = 1;
-        }
-        // Movement in lower portion (backward)
-        else if (y > rect.height * 0.7) {
-          moveSpeed.current = 7; // Increased speed from 5 to 7
-          moveDirection.current = -1;
-        }
-        
-        // Look direction based on horizontal position - allow full rotation
-        if (x < rect.width * 0.3) {
-          yawAngle.current -= 0.1; // Remove limits for full rotation
-        } else if (x > rect.width * 0.7) {
-          yawAngle.current += 0.1; // Remove limits for full rotation
-        }
+        isMouseDown.current = true;
+        lastMouseX.current = event.touches[0].clientX;
       }
     };
 
+    const handleTouchMove = (event: TouchEvent) => {
+      if (!isMouseDown.current || event.touches.length !== 1) return;
+      const deltaX = event.touches[0].clientX - lastMouseX.current;
+      lastMouseX.current = event.touches[0].clientX;
+      yawAngle.current += deltaX * 0.003;
+    };
+
     const handleTouchEnd = () => {
-      moveSpeed.current = 0;
-      moveDirection.current = 0;
+      isMouseDown.current = false;
     };
 
     const canvas = document.querySelector('canvas');
     if (canvas) {
-      canvas.addEventListener('touchstart', handleTouchStart, { passive: true });
-      canvas.addEventListener('touchend', handleTouchEnd, { passive: true });
+      canvas.addEventListener('touchstart', handleTouchStart);
+      canvas.addEventListener('touchmove', handleTouchMove);
+      canvas.addEventListener('touchend', handleTouchEnd);
     }
 
     return () => {
       if (canvas) {
         canvas.removeEventListener('touchstart', handleTouchStart);
+        canvas.removeEventListener('touchmove', handleTouchMove);
         canvas.removeEventListener('touchend', handleTouchEnd);
       }
     };
-  }, [canMoveForward]);
+  }, [isMobile]);
 
   useFrame((state, delta) => {
     swayTime.current += delta;
@@ -192,5 +198,9 @@ export const FirstPersonController: React.FC<FirstPersonControllerProps> = ({
     onPositionChange(camera.position);
   });
 
-  return null;
+  return (
+    <>
+      {isMobile && <VirtualJoystick onMove={handleJoystickMove} />}
+    </>
+  );
 };

--- a/src/components/NexusFirstPersonController.tsx
+++ b/src/components/NexusFirstPersonController.tsx
@@ -1,6 +1,8 @@
 import React, { useRef, useEffect } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
 import { Vector3 } from 'three';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { VirtualJoystick } from './VirtualJoystick';
 
 interface NexusFirstPersonControllerProps {
   speed?: number;
@@ -12,6 +14,7 @@ export const NexusFirstPersonController: React.FC<NexusFirstPersonControllerProp
   sensitivity = 0.002
 }) => {
   const { camera } = useThree();
+  const isMobile = useIsMobile();
   const velocity = useRef(new Vector3());
   const direction = useRef(new Vector3());
   const euler = useRef(new Vector3());
@@ -28,6 +31,13 @@ export const NexusFirstPersonController: React.FC<NexusFirstPersonControllerProp
   const isLocked = useRef(false);
   const yaw = useRef(0);
   const pitch = useRef(0);
+
+  const handleJoystickMove = (dx: number, dy: number) => {
+    keys.current.forward = dy < -0.3;
+    keys.current.backward = dy > 0.3;
+    keys.current.left = dx < -0.3;
+    keys.current.right = dx > 0.3;
+  };
 
   useEffect(() => {
     // Initialize camera position
@@ -199,5 +209,9 @@ export const NexusFirstPersonController: React.FC<NexusFirstPersonControllerProp
     camera.up.set(0, 1, 0);
   });
 
-  return null;
+  return (
+    <>
+      {isMobile && <VirtualJoystick onMove={handleJoystickMove} />}
+    </>
+  );
 };

--- a/src/components/VirtualJoystick.tsx
+++ b/src/components/VirtualJoystick.tsx
@@ -1,0 +1,59 @@
+import React, { useRef } from 'react';
+
+interface VirtualJoystickProps {
+  onMove: (dx: number, dy: number) => void;
+}
+
+export const VirtualJoystick: React.FC<VirtualJoystickProps> = ({ onMove }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const knobRef = useRef<HTMLDivElement>(null);
+  const dragging = useRef(false);
+
+  const move = (clientX: number, clientY: number) => {
+    if (!containerRef.current || !knobRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const x = clientX - rect.left - rect.width / 2;
+    const y = clientY - rect.top - rect.height / 2;
+    const radius = rect.width / 2;
+    const distance = Math.min(Math.sqrt(x * x + y * y), radius);
+    const angle = Math.atan2(y, x);
+    const nx = (distance * Math.cos(angle)) / radius;
+    const ny = (distance * Math.sin(angle)) / radius;
+    knobRef.current.style.transform = `translate(${nx * radius}px, ${ny * radius}px)`;
+    onMove(nx, ny);
+  };
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    dragging.current = true;
+    move(e.clientX, e.clientY);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragging.current) return;
+    move(e.clientX, e.clientY);
+  };
+
+  const handlePointerUp = () => {
+    dragging.current = false;
+    if (knobRef.current) {
+      knobRef.current.style.transform = 'translate(-50%, -50%)';
+    }
+    onMove(0, 0);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="absolute bottom-4 left-4 h-24 w-24 rounded-full bg-gray-700 bg-opacity-50 select-none touch-none"
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerLeave={handlePointerUp}
+    >
+      <div
+        ref={knobRef}
+        className="pointer-events-none absolute left-1/2 top-1/2 h-12 w-12 -translate-x-1/2 -translate-y-1/2 rounded-full bg-gray-300 bg-opacity-80"
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add `VirtualJoystick` component for touch devices
- use joystick in fantasy and nexus first-person controllers
- speed up scifi vertical scrolling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6878035851c8832eb90986cf1a08b631