### PR TITLE
Fix skeleton loading with base URL

### DIFF
--- a/src/components/SkeletonEnemySystem.tsx
+++ b/src/components/SkeletonEnemySystem.tsx
@@ -3,11 +3,12 @@ import { useFrame } from '@react-three/fiber';
 import { Vector3, Group } from 'three';
 import { useGLTF } from '@react-three/drei';
 import { ChunkData } from './ChunkSystem';
+import { assetUrl } from '@/lib/utils';
 
 // Preload skeleton models to avoid loading hitches
-useGLTF.preload('/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Minion.glb');
-useGLTF.preload('/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Rogue.glb');
-useGLTF.preload('/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Warrior.glb');
+useGLTF.preload(assetUrl('assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Minion.glb'));
+useGLTF.preload(assetUrl('assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Rogue.glb'));
+useGLTF.preload(assetUrl('assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Warrior.glb'));
 
 interface SkeletonEnemySystemProps {
   chunks: ChunkData[];
@@ -35,9 +36,9 @@ interface SkeletonEnemy {
 }
 
 const modelPaths: Record<SkeletonType, string> = {
-  minion: '/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Minion.glb',
-  rogue: '/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Rogue.glb',
-  warrior: '/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Warrior.glb'
+  minion: assetUrl('assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Minion.glb'),
+  rogue: assetUrl('assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Rogue.glb'),
+  warrior: assetUrl('assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Warrior.glb')
 };
 
 const SkeletonModel: React.FC<{

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function assetUrl(path: string) {
+  const base = import.meta.env.BASE_URL || '/'
+  const baseTrimmed = base.endsWith('/') ? base.slice(0, -1) : base
+  const trimmed = path.startsWith('/') ? path.slice(1) : path
+  return `${baseTrimmed}/${trimmed}`
+}


### PR DESCRIPTION
## Summary
- fix skeleton model paths so they respect `vite` base URL
- add `assetUrl` helper

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879626a3214832e83a2cc7dfd165662