### PR TITLE
Fix repeating upgrade pedestals

### DIFF
--- a/src/components/EnhancedUpgradePedestal.tsx
+++ b/src/components/EnhancedUpgradePedestal.tsx
@@ -13,6 +13,7 @@ interface EnhancedUpgradePedestalProps {
   canAfford: boolean;
   onInteract: () => void;
   tier: number;
+  modelType?: 'podium' | 'obelisk';
 }
 
 export const EnhancedUpgradePedestal: React.FC<EnhancedUpgradePedestalProps> = ({
@@ -22,7 +23,8 @@ export const EnhancedUpgradePedestal: React.FC<EnhancedUpgradePedestalProps> = (
   isPurchased,
   canAfford,
   onInteract,
-  tier
+  tier,
+  modelType = 'podium'
 }) => {
   const meshRef = useRef<Group>(null);
   const glowRef = useRef<Mesh>(null);
@@ -89,11 +91,16 @@ export const EnhancedUpgradePedestal: React.FC<EnhancedUpgradePedestalProps> = (
     setHovered(false);
   };
 
-  // Podium model using the GLB file
-  const PodiumModel = () => {
+  // Pedestal/obelisk model using GLB files
+  const PedestalModel = () => {
+    const assetPath =
+      modelType === 'obelisk'
+        ? '/assets/upgrades/LargeObelisk.glb'
+        : '/assets/upgrades/Podiums.glb';
+
     try {
-      const { scene } = useGLTF('/assets/upgrades/Podiums.glb');
-      
+      const { scene } = useGLTF(assetPath);
+
       return (
         <group
           ref={meshRef}
@@ -103,23 +110,24 @@ export const EnhancedUpgradePedestal: React.FC<EnhancedUpgradePedestalProps> = (
           scale={hovered ? 1.05 : 1.0}
         >
           <primitive object={scene.clone()} />
-          
-          {/* Crystal/upgrade indicator on top */}
-          <mesh position={[0, 1.4, 0]} castShadow>
-            {tier === 1 && <tetrahedronGeometry args={[0.5]} />}
-            {tier === 2 && <octahedronGeometry args={[0.6]} />}
-            {tier === 3 && <dodecahedronGeometry args={[0.7]} />}
-            {tier >= 4 && <icosahedronGeometry args={[0.8, 1]} />}
-            <meshLambertMaterial
-              color={getCrystalColor()}
-              transparent
-              opacity={isUnlocked ? 0.9 : 0.5}
-            />
-          </mesh>
+
+          {modelType !== 'obelisk' && (
+            <mesh position={[0, 1.4, 0]} castShadow>
+              {tier === 1 && <tetrahedronGeometry args={[0.5]} />}
+              {tier === 2 && <octahedronGeometry args={[0.6]} />}
+              {tier === 3 && <dodecahedronGeometry args={[0.7]} />}
+              {tier >= 4 && <icosahedronGeometry args={[0.8, 1]} />}
+              <meshLambertMaterial
+                color={getCrystalColor()}
+                transparent
+                opacity={isUnlocked ? 0.9 : 0.5}
+              />
+            </mesh>
+          )}
         </group>
       );
     } catch (error) {
-      console.error('Error loading Podiums.glb:', error);
+      console.error('Error loading upgrade model:', error);
       return null;
     }
   };
@@ -138,9 +146,9 @@ export const EnhancedUpgradePedestal: React.FC<EnhancedUpgradePedestalProps> = (
         <meshBasicMaterial transparent opacity={0} />
       </mesh>
 
-      {/* New podium model for all upgrades */}
+      {/* Pedestal or obelisk model */}
       <Suspense fallback={null}>
-        <PodiumModel />
+        <PedestalModel />
       </Suspense>
       
       {/* Magical glow effect around podium base */}
@@ -209,3 +217,4 @@ export const EnhancedUpgradePedestal: React.FC<EnhancedUpgradePedestalProps> = (
 
 // Preload the GLB model
 useGLTF.preload('/assets/upgrades/Podiums.glb');
+useGLTF.preload('/assets/upgrades/LargeObelisk.glb');

--- a/src/components/Fantasy3DUpgradePedestals.tsx
+++ b/src/components/Fantasy3DUpgradePedestals.tsx
@@ -34,6 +34,7 @@ export const Fantasy3DUpgradePedestals: React.FC<Fantasy3DUpgradePedestalsProps>
             canAfford={currentManaRef.current >= upgrade.cost}
             onInteract={() => onUpgradeClick(upgrade)}
             tier={upgrade.tier + 1}
+            modelType={upgrade.modelType}
           />
         );
       })}

--- a/src/components/hooks/useFantasy3DUpgradeWorld.tsx
+++ b/src/components/hooks/useFantasy3DUpgradeWorld.tsx
@@ -32,69 +32,103 @@ export const useFantasy3DUpgradeWorld = ({
   const RENDER_DISTANCE = 200;
   const UPGRADE_SPACING = 35;
 
-  // Create upgrades placed along the fantasy path
-  const upgrades = [
+  // Base template for the repeating upgrade sequence
+  const upgradeTemplates = [
     {
-      id: 0,
       name: 'Mana Crystal',
       cost: 50,
       manaPerSecond: 3,
-      position: [-12, 0.5, -30],
-      tier: 0,
-      unlocked: true,
-      description: 'A crystallized form of pure magical energy'
+      description: 'A crystallized form of pure magical energy',
+      modelType: 'podium' as const
     },
     {
-      id: 1,
       name: 'Arcane Focus',
       cost: 250,
       manaPerSecond: 12,
-      position: [12, 0.5, -60],
-      tier: 1,
-      unlocked: maxUnlockedUpgrade >= 0,
-      description: 'Concentrates magical energies for greater efficiency'
+      description: 'Concentrates magical energies for greater efficiency',
+      modelType: 'podium' as const
     },
     {
-      id: 2,
       name: 'Mystic Fountain',
       cost: 1000,
       manaPerSecond: 30,
-      position: [-12, 0.5, -90],
-      tier: 2,
-      unlocked: maxUnlockedUpgrade >= 1,
-      description: 'An eternal wellspring of magical power'
+      description: 'An eternal wellspring of magical power',
+      modelType: 'podium' as const
     },
     {
-      id: 3,
       name: 'Elder Artifact',
       cost: 5000,
       manaPerSecond: 100,
-      position: [12, 0.5, -120],
-      tier: 3,
-      unlocked: maxUnlockedUpgrade >= 2,
-      description: 'Ancient relic of immense magical power'
+      description: 'Ancient relic of immense magical power',
+      modelType: 'podium' as const
     },
     {
-      id: 4,
-      name: 'Dragon Shrine',
-      cost: 25000,
-      manaPerSecond: 400,
-      position: [-12, 0.5, -150],
-      tier: 4,
-      unlocked: maxUnlockedUpgrade >= 3,
-      description: 'A sacred shrine blessed by ancient dragons'
-    },
-    {
-      id: 5,
       name: 'Celestial Nexus',
       cost: 100000,
       manaPerSecond: 1500,
-      position: [12, 0.5, -180],
-      tier: 5,
-      unlocked: maxUnlockedUpgrade >= 4,
-      description: 'Connects to the cosmic web of magical energy'
+      description: 'Connects to the cosmic web of magical energy',
+      modelType: 'obelisk' as const
     }
   ];
+
+  interface UpgradeData {
+    id: number;
+    name: string;
+    cost: number;
+    manaPerSecond: number;
+    position: [number, number, number];
+    tier: number;
+    unlocked: boolean;
+    description: string;
+    modelType: 'podium' | 'obelisk';
+  }
+
+  const createUpgrade = (index: number): UpgradeData => {
+    const template = upgradeTemplates[index % upgradeTemplates.length];
+    const lane = index % 2 === 0 ? -12 : 12;
+    return {
+      id: index,
+      name: template.name,
+      cost: template.cost,
+      manaPerSecond: template.manaPerSecond,
+      description: template.description,
+      modelType: template.modelType,
+      position: [lane, 0.5, -30 - index * UPGRADE_SPACING],
+      tier: index % upgradeTemplates.length,
+      unlocked: index === 0 || maxUnlockedUpgrade >= index - 1
+    };
+  };
+
+  const [upgrades, setUpgrades] = useState<UpgradeData[]>(() =>
+    Array.from({ length: 10 }).map((_, i) => createUpgrade(i))
+  );
+
+  // Extend the upgrade list as the player moves forward
+  useEffect(() => {
+    setUpgrades(prev => {
+      const last = prev[prev.length - 1];
+      const distanceAhead = Math.abs(last.position[2] - cameraPosition.z);
+      if (distanceAhead < RENDER_DISTANCE) {
+        const next: UpgradeData[] = [];
+        let index = prev.length;
+        for (let i = 0; i < 5; i++) {
+          next.push(createUpgrade(index++));
+        }
+        return [...prev, ...next];
+      }
+      return prev;
+    });
+  }, [cameraPosition.z]);
+
+  // Update unlock status when new upgrades are purchased
+  useEffect(() => {
+    setUpgrades(prev =>
+      prev.map(u => ({
+        ...u,
+        unlocked: u.id === 0 || maxUnlockedUpgrade >= u.id - 1
+      }))
+    );
+  }, [maxUnlockedUpgrade]);
 
   // Update refs when gameState changes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add `modelType` support to `EnhancedUpgradePedestal`
- spawn correct upgrade model (podium vs obelisk)
- pass pedestal type from `Fantasy3DUpgradePedestals`
- generate infinite upgrade sequence in `useFantasy3DUpgradeWorld`

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687e80b50594832eb46168f55ca1c0a7