### PR TITLE
Fix GLB asset paths

### DIFF
--- a/src/components/EnhancedUpgradePedestal.tsx
+++ b/src/components/EnhancedUpgradePedestal.tsx
@@ -4,6 +4,7 @@ import { useFrame } from '@react-three/fiber';
 import { Group, Mesh, Vector3 } from 'three';
 import { useRegisterCollider } from '@/lib/CollisionContext';
 import { useGLTF } from '@react-three/drei';
+import { assetUrl } from '@/lib/utils';
 
 interface EnhancedUpgradePedestalProps {
   position: [number, number, number];
@@ -94,10 +95,11 @@ export const EnhancedUpgradePedestal: React.FC<EnhancedUpgradePedestalProps> = (
   // Pedestal/obelisk model using GLB files with fallback
   const PedestalModel = () => {
     try {
-      const assetPath =
+      const assetPath = assetUrl(
         modelType === 'obelisk'
           ? '/assets/upgrades/LargeObelisk.glb'
-          : '/assets/upgrades/Podiums.glb';
+          : '/assets/upgrades/Podiums.glb'
+      );
 
       const { scene } = useGLTF(assetPath);
 
@@ -243,5 +245,5 @@ export const EnhancedUpgradePedestal: React.FC<EnhancedUpgradePedestalProps> = (
 };
 
 // Preload the GLB model
-useGLTF.preload('/assets/upgrades/Podiums.glb');
-useGLTF.preload('/assets/upgrades/LargeObelisk.glb');
+useGLTF.preload(assetUrl('/assets/upgrades/Podiums.glb'));
+useGLTF.preload(assetUrl('/assets/upgrades/LargeObelisk.glb'));

--- a/src/components/InfinitePathSystem.tsx
+++ b/src/components/InfinitePathSystem.tsx
@@ -2,14 +2,16 @@ import React, { useRef, useMemo, Suspense } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Vector3, Box3 } from 'three';
 import { useGLTF } from '@react-three/drei';
+import { assetUrl } from '@/lib/utils';
 
 // Preload the path model immediately
-useGLTF.preload('/assets/Path.glb');
+const PATH_ASSET = assetUrl('/assets/Path.glb');
+useGLTF.preload(PATH_ASSET);
 
 // Path Model Component with direct useGLTF
 const PathModel: React.FC<{ onLoad?: (scene: any) => void }> = ({ onLoad }) => {
   try {
-    const { scene } = useGLTF('/assets/Path.glb');
+    const { scene } = useGLTF(PATH_ASSET);
     
     // Call onLoad when model is successfully loaded
     React.useEffect(() => {

--- a/src/components/LinearForestCorridor.tsx
+++ b/src/components/LinearForestCorridor.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { useGLTF } from '@react-three/drei';
+import { assetUrl } from '@/lib/utils';
 import { Vector3 } from 'three';
 
 interface LinearForestCorridorProps {
@@ -16,13 +17,13 @@ interface ForestElement {
 const ForestAsset: React.FC<{ element: ForestElement }> = ({ element }) => {
   const getModelPath = (type: string): string => {
     const modelPaths: Record<string, string> = {
-      tree1: '/assets/forestGLB/Tree1.glb',
-      tree2: '/assets/forestGLB/Tree2.glb',
-      grass: '/assets/forestGLB/Grass.glb',
-      log: '/assets/forestGLB/FallenLog.glb',
-      rock1: '/assets/forestGLB/SmallRock1.glb',
-      rock2: '/assets/forestGLB/SmallRock2.glb',
-      rock3: '/assets/forestGLB/SmallRock3.glb',
+      tree1: assetUrl('/assets/forestGLB/Tree1.glb'),
+      tree2: assetUrl('/assets/forestGLB/Tree2.glb'),
+      grass: assetUrl('/assets/forestGLB/Grass.glb'),
+      log: assetUrl('/assets/forestGLB/FallenLog.glb'),
+      rock1: assetUrl('/assets/forestGLB/SmallRock1.glb'),
+      rock2: assetUrl('/assets/forestGLB/SmallRock2.glb'),
+      rock3: assetUrl('/assets/forestGLB/SmallRock3.glb'),
     };
     return modelPaths[type] || modelPaths.tree1;
   };
@@ -184,10 +185,10 @@ export const LinearForestCorridor: React.FC<LinearForestCorridorProps> = ({
 };
 
 // Preload GLB models
-useGLTF.preload('/assets/forestGLB/Tree1.glb');
-useGLTF.preload('/assets/forestGLB/Tree2.glb');
-useGLTF.preload('/assets/forestGLB/Grass.glb');
-useGLTF.preload('/assets/forestGLB/FallenLog.glb');
-useGLTF.preload('/assets/forestGLB/SmallRock1.glb');
-useGLTF.preload('/assets/forestGLB/SmallRock2.glb');
-useGLTF.preload('/assets/forestGLB/SmallRock3.glb');
+useGLTF.preload(assetUrl('/assets/forestGLB/Tree1.glb'));
+useGLTF.preload(assetUrl('/assets/forestGLB/Tree2.glb'));
+useGLTF.preload(assetUrl('/assets/forestGLB/Grass.glb'));
+useGLTF.preload(assetUrl('/assets/forestGLB/FallenLog.glb'));
+useGLTF.preload(assetUrl('/assets/forestGLB/SmallRock1.glb'));
+useGLTF.preload(assetUrl('/assets/forestGLB/SmallRock2.glb'));
+useGLTF.preload(assetUrl('/assets/forestGLB/SmallRock3.glb'));

--- a/src/components/MountainWalls.tsx
+++ b/src/components/MountainWalls.tsx
@@ -1,12 +1,13 @@
 
 import React, { useRef, useEffect } from 'react';
 import { useGLTF } from '@react-three/drei';
+import { assetUrl } from '@/lib/utils';
 import { Group, Mesh } from 'three';
 import { useThree } from '@react-three/fiber';
 
 export const MountainWalls: React.FC = () => {
   const { scene } = useThree();
-  const { scene: mountainModel } = useGLTF('./assets/mountain_low_poly.glb');
+  const { scene: mountainModel } = useGLTF(assetUrl('/assets/mountain_low_poly.glb'));
   const mountainsRef = useRef<Group[]>([]);
 
   useEffect(() => {
@@ -79,4 +80,4 @@ export const MountainWalls: React.FC = () => {
 };
 
 // Preload the mountain model
-useGLTF.preload('./assets/mountain_low_poly.glb');
+useGLTF.preload(assetUrl('/assets/mountain_low_poly.glb'));

--- a/src/components/NexusWorld.jsx
+++ b/src/components/NexusWorld.jsx
@@ -1,15 +1,16 @@
 import React, { useRef } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls, useGLTF } from '@react-three/drei';
+import { assetUrl } from '@/lib/utils';
 import * as THREE from 'three';
 
 const Scene = () => {
-  const { scene: crystal } = useGLTF('/models/crystal_obelisk.glb');
-  const { scene: goldVendor } = useGLTF('/models/vendor_gold.glb');
-  const { scene: gemVendor } = useGLTF('/models/vendor_gems.glb');
-  const { scene: tree } = useGLTF('/models/tree.glb');
-  const { scene: fencePost } = useGLTF('/models/fence_post.glb');
-  const { scene: pathTile } = useGLTF('/models/path_tile.glb');
+  const { scene: crystal } = useGLTF(assetUrl('/models/crystal_obelisk.glb'));
+  const { scene: goldVendor } = useGLTF(assetUrl('/models/vendor_gold.glb'));
+  const { scene: gemVendor } = useGLTF(assetUrl('/models/vendor_gems.glb'));
+  const { scene: tree } = useGLTF(assetUrl('/models/tree.glb'));
+  const { scene: fencePost } = useGLTF(assetUrl('/models/fence_post.glb'));
+  const { scene: pathTile } = useGLTF(assetUrl('/models/path_tile.glb'));
 
   const crystalRef = useRef();
 

--- a/src/components/OptimizedPathSegments.tsx
+++ b/src/components/OptimizedPathSegments.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useRef, useEffect } from 'react';
 import { useGLTF } from '@react-three/drei';
+import { assetUrl } from '@/lib/utils';
 import { Object3D, InstancedMesh, Matrix4, Vector3 } from 'three';
 
 interface OptimizedPathSegmentsProps {
@@ -20,7 +21,8 @@ export const OptimizedPathSegments: React.FC<OptimizedPathSegmentsProps> = ({
   renderDistance
 }) => {
   const meshRef = useRef<InstancedMesh>(null);
-  const { scene: pathScene } = useGLTF('/assets/Path.glb');
+  const PATH_URL = assetUrl('/assets/Path.glb');
+  const { scene: pathScene } = useGLTF(PATH_URL);
 
   // Calculate visible segments based on player position
   const visibleSegments = useMemo(() => {

--- a/src/components/PathsideMountains.tsx
+++ b/src/components/PathsideMountains.tsx
@@ -1,12 +1,13 @@
 
 import React, { useRef, useEffect } from 'react';
 import { useGLTF } from '@react-three/drei';
+import { assetUrl } from '@/lib/utils';
 import { Group, Mesh } from 'three';
 import { useThree } from '@react-three/fiber';
 
 export const PathsideMountains: React.FC = () => {
   const { scene } = useThree();
-  const { scene: mountain } = useGLTF('./assets/mountain_low_poly.glb');
+  const { scene: mountain } = useGLTF(assetUrl('/assets/mountain_low_poly.glb'));
   const mountainsRef = useRef<Group[]>([]);
 
   useEffect(() => {
@@ -80,4 +81,4 @@ export const PathsideMountains: React.FC = () => {
 };
 
 // Preload the mountain model
-useGLTF.preload('./assets/mountain_low_poly.glb');
+useGLTF.preload(assetUrl('/assets/mountain_low_poly.glb'));

--- a/src/components/SkeletonEnemySystem.tsx
+++ b/src/components/SkeletonEnemySystem.tsx
@@ -2,13 +2,13 @@ import React, { useMemo, useRef, useState, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Vector3, Group } from 'three';
 import { useGLTF } from '@react-three/drei';
-import { ChunkData } from './ChunkSystem';
 import { assetUrl } from '@/lib/utils';
+import { ChunkData } from './ChunkSystem';
 
 // Preload skeleton models to avoid loading hitches
-useGLTF.preload('/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Minion.glb');
-useGLTF.preload('/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Rogue.glb');
-useGLTF.preload('/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Warrior.glb');
+useGLTF.preload(assetUrl('/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Minion.glb'));
+useGLTF.preload(assetUrl('/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Rogue.glb'));
+useGLTF.preload(assetUrl('/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Warrior.glb'));
 
 interface SkeletonEnemySystemProps {
   chunks: ChunkData[];
@@ -36,9 +36,9 @@ interface SkeletonEnemy {
 }
 
 const modelPaths: Record<SkeletonType, string> = {
-  minion: '/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Minion.glb',
-  rogue: '/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Rogue.glb',
-  warrior: '/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Warrior.glb'
+  minion: assetUrl('/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Minion.glb'),
+  rogue: assetUrl('/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Rogue.glb'),
+  warrior: assetUrl('/assets/KayKit_Skeletons_1.0_FREE/characters/gltf/Skeleton_Warrior.glb')
 };
 
 const SkeletonModel: React.FC<{

--- a/src/components/UpgradeNode3D.tsx
+++ b/src/components/UpgradeNode3D.tsx
@@ -3,6 +3,7 @@ import React, { useRef, useState, useMemo, Suspense } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Group, Mesh } from 'three';
 import { useGLTF } from '@react-three/drei';
+import { assetUrl } from '@/lib/utils';
 
 interface UpgradeNode3DProps {
   upgrade: any;
@@ -80,7 +81,7 @@ export const UpgradeNode3D: React.FC<UpgradeNode3DProps> = React.memo(({
   // Fantasy podium model using GLB file
   const FantasyPodiumModel = () => {
     try {
-      const { scene } = useGLTF('/assets/upgrades/Podiums.glb');
+      const { scene } = useGLTF(assetUrl('/assets/upgrades/Podiums.glb'));
       
       return (
         <group
@@ -186,4 +187,4 @@ export const UpgradeNode3D: React.FC<UpgradeNode3DProps> = React.memo(({
 UpgradeNode3D.displayName = 'UpgradeNode3D';
 
 // Preload the GLB model
-useGLTF.preload('/assets/upgrades/Podiums.glb');
+useGLTF.preload(assetUrl('/assets/upgrades/Podiums.glb'));

--- a/src/lib/assetPreloader.ts
+++ b/src/lib/assetPreloader.ts
@@ -1,18 +1,19 @@
 import { useGLTF } from '@react-three/drei';
 import { preloadCriticalAssets, checkAssetSize } from '@/components/GLBModelLoader';
+import { assetUrl } from '@/lib/utils';
 
 // Critical assets - must be under 15MB each
 const CRITICAL_ASSETS = [
-  '/assets/Path.glb', // Main walking surface
-  '/assets/upgrades/Podiums.glb',
-  '/assets/upgrades/LargeObelisk.glb',
+  assetUrl('/assets/Path.glb'), // Main walking surface
+  assetUrl('/assets/upgrades/Podiums.glb'),
+  assetUrl('/assets/upgrades/LargeObelisk.glb'),
 ];
 
 // Fantasy realm assets
 const FANTASY_ASSETS = [
-  '/assets/terrain/FantasyTree.glb',
-  '/assets/environment/MagicalCrystal.glb',
-  '/assets/characters/SkeletonWarrior.glb',
+  assetUrl('/assets/terrain/FantasyTree.glb'),
+  assetUrl('/assets/environment/MagicalCrystal.glb'),
+  assetUrl('/assets/characters/SkeletonWarrior.glb'),
 ];
 
 // Initialize complete GLB loading system


### PR DESCRIPTION
## Summary
- fix GLB asset paths to respect Vite base URL using `assetUrl`
- update model preload calls accordingly
- clean up duplicate import

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e963a1224832ea9a052b87addc427