### PR TITLE
Add chunked fantasy world with GLB assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.9",
         "globals": "^15.9.0",
+        "gltfpack": "^0.24.0",
         "lovable-tagger": "^1.1.7",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.11",
@@ -6449,6 +6450,19 @@
       "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
       "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
       "license": "MIT"
+    },
+    "node_modules/gltfpack": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/gltfpack/-/gltfpack-0.24.0.tgz",
+      "integrity": "sha512-IV+ykiSebCqsSsHM65vZZV2TSWPGNudn9a07dPLYUJ1wmBattF1vNIdZzgAuwfZEPKhg2mQFsIJAXANYfYM50w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "gltfpack": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "BROWSERSLIST_IGNORE_OLD_DATA=true vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "ios": "npx cap sync ios && npx cap open ios"
+    "ios": "npx cap sync ios && npx cap open ios",
+    "compress:glb": "node scripts/compress-glb.js"
   },
   "dependencies": {
     "@capacitor/android": "^7.4.0",
@@ -89,6 +90,7 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.9.0",
+    "gltfpack": "^0.24.0",
     "lovable-tagger": "^1.1.7",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.11",

--- a/scripts/compress-glb.js
+++ b/scripts/compress-glb.js
@@ -1,0 +1,16 @@
+const { execSync } = require('child_process');
+const path = require('path');
+
+const assets = [
+  'public/assets/environment/AncientTree.glb',
+  'public/assets/environment/AncientTree2.glb',
+  'public/assets/environment/Mountains.glb',
+  'public/assets/upgrades/LargeObelisk.glb',
+  'public/assets/Path.glb'
+];
+
+for (const asset of assets) {
+  const output = asset.replace(/\.glb$/, '.compressed.glb');
+  console.log(`Compressing ${asset} -> ${output}`);
+  execSync(`gltfpack -i ${asset} -o ${output} -cc -i -tc`, { stdio: 'inherit' });
+}

--- a/src/components/ChunkedWorld/ChunkedFantasyWorld.tsx
+++ b/src/components/ChunkedWorld/ChunkedFantasyWorld.tsx
@@ -1,0 +1,95 @@
+import React, { useMemo } from 'react';
+import { useThree } from '@react-three/fiber';
+import { Vector3 } from 'three';
+import { InstancedGLBSystem } from '../InstancedGLBSystem';
+import { LODGLBSystem } from '../LODGLBSystem';
+import { assetUrl } from '@/lib/utils';
+
+// Size of each spatial chunk in meters
+const CHUNK_SIZE = 20;
+
+// Map of chunk coordinates to assets inside that chunk
+interface ChunkAsset {
+  file: string;
+  position: [number, number, number];
+  rotation?: [number, number, number];
+  scale?: number;
+  lod?: boolean; // whether to use LOD system
+}
+
+const worldChunks: Record<string, ChunkAsset[]> = {
+  '0,0': [
+    { file: 'assets/Path.glb', position: [0, -1, 0] },
+    { file: 'assets/environment/AncientTree.glb', position: [2, 0, 5] },
+    { file: 'assets/environment/AncientTree2.glb', position: [-3, 0, 4] }
+  ],
+  '1,0': [
+    { file: 'assets/environment/Mountains.glb', position: [10, 0, 0], scale: 15, lod: true }
+  ],
+  '0,1': [
+    { file: 'assets/upgrades/LargeObelisk.glb', position: [0, 0, 18], scale: 2, lod: true }
+  ]
+};
+
+// Collect transforms for instanced assets across visible chunks
+function collectInstancedData(keys: string[]) {
+  const instanced: Record<string, ChunkAsset[]> = {};
+  const lod: Array<{asset: ChunkAsset; key: string}> = [];
+  keys.forEach((k) => {
+    const assets = worldChunks[k];
+    if (!assets) return;
+    assets.forEach((a) => {
+      if (a.lod) {
+        lod.push({ asset: a, key: k + JSON.stringify(a.position) });
+      } else {
+        if (!instanced[a.file]) instanced[a.file] = [];
+        instanced[a.file].push(a);
+      }
+    });
+  });
+  return { instanced, lod };
+}
+
+export const ChunkedFantasyWorld: React.FC = () => {
+  const { camera } = useThree();
+
+  // Determine which chunks are near the camera
+  const visibleChunkKeys = useMemo(() => {
+    const cx = Math.floor(camera.position.x / CHUNK_SIZE);
+    const cz = Math.floor(camera.position.z / CHUNK_SIZE);
+    const keys: string[] = [];
+    for (let x = cx - 2; x <= cx + 2; x++) {
+      for (let z = cz - 2; z <= cz + 2; z++) {
+        keys.push(`${x},${z}`);
+      }
+    }
+    return keys;
+  }, [camera.position.x, camera.position.z]);
+
+  const { instanced, lod } = useMemo(() => collectInstancedData(visibleChunkKeys), [visibleChunkKeys]);
+
+  return (
+    <group>
+      {Object.entries(instanced).map(([file, transforms]) => (
+        <InstancedGLBSystem
+          key={file}
+          modelUrl={assetUrl(file)}
+          positions={transforms.map((t) => ({ position: t.position, rotation: t.rotation, scale: t.scale }))}
+          maxCount={transforms.length}
+        />
+      ))}
+      {lod.map(({ asset, key }) => (
+        <LODGLBSystem
+          key={key}
+          modelUrl={assetUrl(asset.file)}
+          position={asset.position}
+          rotation={asset.rotation}
+          scale={asset.scale}
+          lodDistances={[40, 80, 120]}
+          cameraPosition={camera.position as Vector3}
+        />
+      ))}
+    </group>
+  );
+};
+export default ChunkedFantasyWorld;

--- a/src/pages/NexusWorld.tsx
+++ b/src/pages/NexusWorld.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, lazy } from 'react';
 import { useNavigate } from 'react-router-dom';
-// Lazy load the 3D scene component to avoid blocking the initial render
-const NexusWorldScene = lazy(() => import('@/components/NexusWorld/Nexus3DWorld'));
+// Lazy load the chunked 3D scene component
+const NexusWorldScene = lazy(() => import('@/components/ChunkedWorld/ChunkedFantasyWorld'));
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { BottomActionBar } from '@/components/BottomActionBar';
 


### PR DESCRIPTION
## Summary
- introduce a new `ChunkedFantasyWorld` that loads nearby spatial chunks only
- lazily load the new world page
- add `gltfpack` dev dependency and compression script

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687faaff6014832eb62a831d4e0be9ca