### PR TITLE
Disable decorative GLB assets

### DIFF
--- a/src/components/ChunkedWorld/ChunkedFantasyWorld.tsx
+++ b/src/components/ChunkedWorld/ChunkedFantasyWorld.tsx
@@ -19,12 +19,10 @@ interface ChunkAsset {
 
 const worldChunks: Record<string, ChunkAsset[]> = {
   '0,0': [
-    { file: 'assets/Path.glb', position: [0, -1, 0] },
-    { file: 'assets/environment/AncientTree.glb', position: [2, 0, 5] },
-    { file: 'assets/environment/AncientTree2.glb', position: [-3, 0, 4] }
+    // Decorative assets disabled
   ],
   '1,0': [
-    { file: 'assets/environment/Mountains.glb', position: [10, 0, 0], scale: 15, lod: true }
+    // Decorative assets disabled
   ],
   '0,1': [
     { file: 'assets/upgrades/LargeObelisk.glb', position: [0, 0, 18], scale: 2, lod: true }

--- a/src/components/Fantasy3DScene.tsx
+++ b/src/components/Fantasy3DScene.tsx
@@ -8,9 +8,10 @@ import { OptimizedFantasyEnvironment } from './OptimizedFantasyEnvironment';
 import { CasualFog } from './CasualFog';
 import { Sun } from './Sun';
 import { MagicStaffWeaponSystem } from './MagicStaffWeaponSystem';
-import { LinearForestCorridor } from './LinearForestCorridor';
-import { InfinitePathSystem } from './InfinitePathSystem';
-import { OptimizedStartingForestBarrier } from './OptimizedStartingForestBarrier';
+// Temporarily disable decorative GLB-based systems
+// import { LinearForestCorridor } from './LinearForestCorridor';
+// import { InfinitePathSystem } from './InfinitePathSystem';
+// import { OptimizedStartingForestBarrier } from './OptimizedStartingForestBarrier';
 
 import { PerformanceOptimizer } from './PerformanceOptimizer';
 import { UltimateFantasyOptimizer } from './UltimateFantasyOptimizer';
@@ -47,6 +48,7 @@ export const Fantasy3DScene: React.FC<Fantasy3DSceneProps> = React.memo(({
   upgradesPurchased = 0
 }) => {
   const [enemyCount, setEnemyCount] = useState(0);
+  const showDecorations = false;
 
   // Initialize optimization systems once
   useEffect(() => {
@@ -113,19 +115,19 @@ export const Fantasy3DScene: React.FC<Fantasy3DSceneProps> = React.memo(({
             damage={weaponDamage}
           />
 
-          {/* Optimized forest barrier with instanced GLB trees */}
-          <OptimizedStartingForestBarrier playerPosition={safeCameraPosition} />
-
-          {/* Reduced path system for performance */}
-          <InfinitePathSystem
-            playerPosition={safeCameraPosition}
-            chunksAhead={6}      // Reduced from 8
-            chunksBehind={1}     // Reduced from 2
-            renderDistance={25}  // Heavily reduced for 60 FPS
-          />
-
-          {/* Reduced forest corridor */}
-          <LinearForestCorridor playerPosition={safeCameraPosition} />
+          {/* Decorative GLB systems temporarily disabled */}
+          {showDecorations && (
+            <>
+              <OptimizedStartingForestBarrier playerPosition={safeCameraPosition} />
+              <InfinitePathSystem
+                playerPosition={safeCameraPosition}
+                chunksAhead={6}
+                chunksBehind={1}
+                renderDistance={25}
+              />
+              <LinearForestCorridor playerPosition={safeCameraPosition} />
+            </>
+          )}
 
           <FogBasedChunkSystem
             playerPosition={safeCameraPosition}

--- a/src/components/OptimizedFantasyEnvironment.tsx
+++ b/src/components/OptimizedFantasyEnvironment.tsx
@@ -2,9 +2,10 @@
 import React, { Suspense } from 'react';
 import { FogChunkData } from './FogBasedChunkSystem';
 import { Vector3 } from 'three';
-import { OptimizedGLBTreeSystem } from './OptimizedGLBTreeSystem';
-import { OptimizedMountainSystem } from './OptimizedMountainSystem';
-import { OptimizedPathSystem } from './OptimizedPathSystem';
+// GLB-based decorative systems are disabled for now
+// import { OptimizedGLBTreeSystem } from './OptimizedGLBTreeSystem';
+// import { OptimizedMountainSystem } from './OptimizedMountainSystem';
+// import { OptimizedPathSystem } from './OptimizedPathSystem';
 import { SeamlessGroundSystem } from './SeamlessGroundSystem';
 import { ForestEnvironmentSystem } from './ForestEnvironmentSystem';
 import { SkeletonEnemySystem } from './SkeletonEnemySystem';
@@ -38,31 +39,33 @@ export const OptimizedFantasyEnvironment: React.FC<OptimizedFantasyEnvironmentPr
     return null;
   }
 
+  const showDecorations = false;
+
   // console.log(`OptimizedFantasyEnvironment: Rendering fantasy realm with forest and skeleton systems`);
 
   return (
     <Suspense fallback={null}>
-      {/* Optimized GLB-based path system */}
-      <OptimizedPathSystem
-        playerPosition={playerPosition}
-        chunksAhead={8}
-        chunksBehind={2}
-        chunkSize={chunkSize}
-      />
-      
-      {/* Optimized GLB-based tree system with instancing */}
-      <OptimizedGLBTreeSystem
-        chunks={chunks}
-        chunkSize={chunkSize}
-        realm={realm}
-        playerPosition={playerPosition}
-      />
-
-      {/* Optimized GLB-based mountain system with LOD */}
-      <OptimizedMountainSystem
-        playerPosition={playerPosition}
-        realm={realm}
-      />
+      {/* Decorative GLB systems temporarily disabled */}
+      {showDecorations && (
+        <>
+          <OptimizedPathSystem
+            playerPosition={playerPosition}
+            chunksAhead={8}
+            chunksBehind={2}
+            chunkSize={chunkSize}
+          />
+          <OptimizedGLBTreeSystem
+            chunks={chunks}
+            chunkSize={chunkSize}
+            realm={realm}
+            playerPosition={playerPosition}
+          />
+          <OptimizedMountainSystem
+            playerPosition={playerPosition}
+            realm={realm}
+          />
+        </>
+      )}
 
       {/* Seamless fog-based ground system */}
       <SeamlessGroundSystem

--- a/src/hooks/useGLBSceneReuse.ts
+++ b/src/hooks/useGLBSceneReuse.ts
@@ -41,10 +41,7 @@ export const useGLBSceneReuse = (url: string) => {
 // Preload critical GLB assets with compression awareness
 export const preloadGLBAssets = () => {
   const assets = [
-    'assets/Path.glb',
-    'assets/environment/AncientTree.glb', 
-    'assets/environment/AncientTree2.glb',
-    'assets/environment/Mountains.glb',
+    // Decorative assets disabled
     'assets/upgrades/Podiums.glb',
     'assets/upgrades/LargeObelisk.glb'
   ];

--- a/src/lib/assetPreloader.ts
+++ b/src/lib/assetPreloader.ts
@@ -3,17 +3,13 @@ import { assetUrl } from '@/lib/utils';
 
 // Critical assets - must be under 15MB each
 const CRITICAL_ASSETS = [
-  assetUrl('assets/Path.glb'), // Main walking surface
+  // assetUrl('assets/Path.glb'), // Temporarily disabled
   assetUrl('assets/upgrades/Podiums.glb'),
   assetUrl('assets/upgrades/LargeObelisk.glb'),
 ];
 
 // Fantasy realm assets - all available GLB files
-const FANTASY_ASSETS = [
-  assetUrl('assets/environment/AncientTree.glb'),
-  assetUrl('assets/environment/AncientTree2.glb'), 
-  assetUrl('assets/environment/Mountains.glb'),
-];
+const FANTASY_ASSETS: string[] = [];
 
 // Preload critical assets using useGLTF
 const preloadAssets = (paths: string[]) => {


### PR DESCRIPTION
## Summary
- stop loading path, tree, and mountain GLB models
- disable decorative systems in the fantasy scene

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687fb2665c84832eb760e9203bbd8b20