### PR TITLE
Switch from GLB assets to polygonal models

### DIFF
--- a/src/components/CPUUsageOptimizer.tsx
+++ b/src/components/CPUUsageOptimizer.tsx
@@ -15,7 +15,7 @@ export const CPUUsageOptimizer: React.FC<CPUUsageOptimizerProps> = ({ enabled = 
     if (!enabled) return;
 
     // Throttle animations for better CPU usage
-    let frameThrottle = false;
+    const frameThrottle = false;
     const throttleDelay = 16; // ~60fps
 
     // Optimize React dev tools if present

--- a/src/components/MountainWalls.tsx
+++ b/src/components/MountainWalls.tsx
@@ -1,17 +1,36 @@
 
 import React, { useRef, useEffect } from 'react';
-import { useGLTF } from '@react-three/drei';
-import { Group, Mesh } from 'three';
+import { Group, Mesh, ConeGeometry, MeshStandardMaterial, Mesh as ThreeMesh } from 'three';
 import { useThree } from '@react-three/fiber';
-import { assetUrl } from '@/lib/utils';
 
 export const MountainWalls: React.FC = () => {
   const { scene } = useThree();
-  const { scene: mountainModel } = useGLTF(assetUrl('assets/mountain_low_poly.glb'));
   const mountainsRef = useRef<Group[]>([]);
 
   useEffect(() => {
-    if (!mountainModel) return;
+    const createMountain = (scale: number) => {
+      const group = new Group();
+      const main = new ThreeMesh(
+        new ConeGeometry(8 * scale, 12 * scale, 8),
+        new MeshStandardMaterial({ color: '#6B7280' })
+      );
+      const second = new ThreeMesh(
+        new ConeGeometry(6 * scale, 10 * scale, 6),
+        new MeshStandardMaterial({ color: '#4B5563' })
+      );
+      second.position.set(4 * scale, 0, 3 * scale);
+      const third = new ThreeMesh(
+        new ConeGeometry(5 * scale, 8 * scale, 6),
+        new MeshStandardMaterial({ color: '#374151' })
+      );
+      third.position.set(-3 * scale, 0, -2 * scale);
+      [main, second, third].forEach(m => {
+        m.castShadow = true;
+        m.receiveShadow = true;
+      });
+      group.add(main, second, third);
+      return group;
+    };
 
     // Clean up existing mountains
     mountainsRef.current.forEach(mountain => {
@@ -19,65 +38,33 @@ export const MountainWalls: React.FC = () => {
     });
     mountainsRef.current = [];
 
-    const clonesPerSide = 8; // More mountains for better wall effect
-    const spacingZ = 15; // Spacing between mountains
-    const startZ = 20; // Start ahead of player
-    
-    // console.log('MountainWalls: Creating mountain wall with', clonesPerSide, 'mountains per side');
+    const clonesPerSide = 8;
+    const spacingZ = 15;
+    const startZ = 20;
 
     for (let i = 0; i < clonesPerSide; i++) {
       const z = startZ - (i * spacingZ);
 
-      // Left side mountains (mirrored)
-      const leftMountain = mountainModel.clone() as Group;
+      const leftMountain = createMountain(3);
       leftMountain.position.set(-25, 0, z);
-      leftMountain.scale.set(-3, 3, 3);
-      leftMountain.castShadow = true;
-      leftMountain.receiveShadow = true;
-      
-      // Apply materials for visibility
-      leftMountain.traverse((child) => {
-        if ((child as Mesh).isMesh) {
-          child.castShadow = true;
-          child.receiveShadow = true;
-        }
-      });
-      
+      leftMountain.scale.x *= -1;
       scene.add(leftMountain);
       mountainsRef.current.push(leftMountain);
 
-      // Right side mountains (normal)
-      const rightMountain = mountainModel.clone() as Group;
+      const rightMountain = createMountain(3);
       rightMountain.position.set(25, 0, z);
-      rightMountain.scale.set(3, 3, 3);
-      rightMountain.castShadow = true;
-      rightMountain.receiveShadow = true;
-      
-      // Apply materials for visibility
-      rightMountain.traverse((child) => {
-        if ((child as Mesh).isMesh) {
-          child.castShadow = true;
-          child.receiveShadow = true;
-        }
-      });
-      
       scene.add(rightMountain);
       mountainsRef.current.push(rightMountain);
     }
 
-    // console.log('MountainWalls: Added', mountainsRef.current.length, 'mountains to scene');
-
-    // Cleanup function
     return () => {
       mountainsRef.current.forEach(mountain => {
         scene.remove(mountain);
       });
       mountainsRef.current = [];
     };
-  }, [mountainModel, scene]);
+  }, [scene]);
 
   return null;
 };
 
-// Preload the mountain model
-useGLTF.preload(assetUrl('assets/mountain_low_poly.glb'));

--- a/src/components/NexusWorld.jsx
+++ b/src/components/NexusWorld.jsx
@@ -7,9 +7,7 @@ const Scene = () => {
   const { scene: crystal } = useGLTF('/models/crystal_obelisk.glb');
   const { scene: goldVendor } = useGLTF('/models/vendor_gold.glb');
   const { scene: gemVendor } = useGLTF('/models/vendor_gems.glb');
-  const { scene: tree } = useGLTF('/models/tree.glb');
   const { scene: fencePost } = useGLTF('/models/fence_post.glb');
-  const { scene: pathTile } = useGLTF('/models/path_tile.glb');
 
   const crystalRef = useRef();
 
@@ -38,15 +36,17 @@ const Scene = () => {
         <meshStandardMaterial color="#4caf50" />
       </mesh>
 
-      {/* Path */}
+      {/* Path - simple polygon walkway */}
       {Array.from({ length: 6 }).map((_, i) => (
-        <primitive
-          key={i}
-          object={pathTile.clone()}
-          position={[0, 0, 3 - i]}
+        <mesh
+          key={`path-${i}`}
+          position={[0, 0.01, 3 - i]}
           rotation={[-Math.PI / 2, 0, 0]}
-          scale={1.2}
-        />
+          receiveShadow
+        >
+          <planeGeometry args={[2.4, 2.4, 2, 2]} />
+          <meshStandardMaterial color="#c2b280" />
+        </mesh>
       ))}
 
       {/* Crystal */}
@@ -61,9 +61,18 @@ const Scene = () => {
       <primitive object={goldVendor.clone()} position={[-3, 0, 2]} scale={1.2} />
       <primitive object={gemVendor.clone()} position={[3, 0, 2]} scale={1.2} />
 
-      {/* Trees */}
+      {/* Trees - polygon models */}
       {treePositions.map((pos, idx) => (
-        <primitive key={idx} object={tree.clone()} position={pos} scale={2} />
+        <group key={`tree-${idx}`} position={pos} scale={2}>
+          <mesh castShadow receiveShadow>
+            <cylinderGeometry args={[0.1, 0.2, 1.5, 6]} />
+            <meshStandardMaterial color="#8b5a2b" />
+          </mesh>
+          <mesh position={[0, 1.2, 0]} castShadow receiveShadow>
+            <coneGeometry args={[0.9, 2, 8]} />
+            <meshStandardMaterial color="#228b22" />
+          </mesh>
+        </group>
       ))}
 
       {/* Fence Posts */}

--- a/src/components/ProceduralMountainSystem.tsx
+++ b/src/components/ProceduralMountainSystem.tsx
@@ -1,11 +1,7 @@
 import React, { useMemo } from 'react';
-import { useGLTF } from '@react-three/drei';
 import { Vector3 } from 'three';
-import { assetUrl } from '@/lib/utils';
 import { FogChunkData } from './FogBasedChunkSystem';
 
-// Preload the mountains model
-useGLTF.preload(assetUrl('assets/environment/Mountains.glb'));
 
 interface ProceduralMountainSystemProps {
   chunks: FogChunkData[];
@@ -22,43 +18,27 @@ interface MountainInstance {
 }
 
 // Mountain Model Component
-const MountainModel: React.FC<{ 
-  position: [number, number, number]; 
-  rotation: [number, number, number]; 
-  scale: number 
+const MountainModel: React.FC<{
+  position: [number, number, number];
+  rotation: [number, number, number];
+  scale: number
 }> = ({ position, rotation, scale }) => {
-  try {
-    const { scene } = useGLTF(assetUrl('assets/environment/Mountains.glb'));
-    return (
-      <primitive 
-        object={scene.clone()} 
-        position={position}
-        rotation={rotation}
-        scale={[scale, scale, scale]}
-        castShadow 
-        receiveShadow 
-      />
-    );
-  } catch (error) {
-    console.warn('Failed to load Mountains.glb, using fallback:', error);
-    // Fallback mountain geometry
-    return (
-      <group position={position} rotation={rotation}>
-        <mesh castShadow receiveShadow>
-          <coneGeometry args={[8 * scale, 12 * scale, 8]} />
-          <meshStandardMaterial color="#6B7280" />
-        </mesh>
-        <mesh position={[4 * scale, 0, 3 * scale]} castShadow receiveShadow>
-          <coneGeometry args={[6 * scale, 10 * scale, 6]} />
-          <meshStandardMaterial color="#4B5563" />
-        </mesh>
-        <mesh position={[-3 * scale, 0, -2 * scale]} castShadow receiveShadow>
-          <coneGeometry args={[5 * scale, 8 * scale, 6]} />
-          <meshStandardMaterial color="#374151" />
-        </mesh>
-      </group>
-    );
-  }
+  return (
+    <group position={position} rotation={rotation}>
+      <mesh castShadow receiveShadow>
+        <coneGeometry args={[8 * scale, 12 * scale, 8]} />
+        <meshStandardMaterial color="#6B7280" />
+      </mesh>
+      <mesh position={[4 * scale, 0, 3 * scale]} castShadow receiveShadow>
+        <coneGeometry args={[6 * scale, 10 * scale, 6]} />
+        <meshStandardMaterial color="#4B5563" />
+      </mesh>
+      <mesh position={[-3 * scale, 0, -2 * scale]} castShadow receiveShadow>
+        <coneGeometry args={[5 * scale, 8 * scale, 6]} />
+        <meshStandardMaterial color="#374151" />
+      </mesh>
+    </group>
+  );
 };
 
 export const ProceduralMountainSystem: React.FC<ProceduralMountainSystemProps> = ({


### PR DESCRIPTION
## Summary
- drop tree and path GLB usage in `NexusWorld`
- create polygon path tiles and tree meshes
- replace mountain GLB logic with polygon geometry in `MountainWalls` and `ProceduralMountainSystem`
- fix lint issues

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687fcdaca260832ea29ec0d315a10403