### PR TITLE
Fix spawn orientation and enforce 60 FPS

### DIFF
--- a/src/components/ChunkSystem.tsx
+++ b/src/components/ChunkSystem.tsx
@@ -43,34 +43,32 @@ export const ChunkSystem: React.FC<ChunkSystemProps> = React.memo(({
     let chunkCount = 0;
     const maxChunks = 60; // Increased from 25 to 60
     
-    // Generate minimal chunks without overlap
+    // Generate chunks only in front of the player
     for (let x = playerChunkX - chunkRadius; x <= playerChunkX + chunkRadius && chunkCount < maxChunks; x++) {
-      for (let z = playerChunkZ - chunkRadius; z <= playerChunkZ + farAheadChunks && chunkCount < maxChunks; z++) {
-        if (z >= -Math.ceil(maxRenderDistance / chunkSize)) {
-          const worldX = x * chunkSize;
-          const worldZ = -z * chunkSize;
-          
-          // PERFORMANCE FIX: Much more aggressive distance-based culling
-          const distanceToPlayer = Math.sqrt(
-            Math.pow(worldX - roundedPlayerX, 2) + 
-            Math.pow(worldZ - roundedPlayerZ, 2)
-          );
-          
-          // PERFORMANCE FIX: Strict distance check without buffer
-          if (distanceToPlayer <= maxRenderDistance) {
-            const seed = ((x & 0xFFFF) << 16) | (z & 0xFFFF);
-            
-            chunks.push({
-              id: `chunk_${x}_${z}`,
-              x,
-              z,
-              worldX,
-              worldZ,
-              seed: Math.abs(seed) % 10000
-            });
-            
-            chunkCount++;
-          }
+      for (let z = playerChunkZ; z <= playerChunkZ + farAheadChunks && chunkCount < maxChunks; z++) {
+        const worldX = x * chunkSize;
+        const worldZ = -z * chunkSize;
+
+        // PERFORMANCE FIX: Much more aggressive distance-based culling
+        const distanceToPlayer = Math.sqrt(
+          Math.pow(worldX - roundedPlayerX, 2) +
+          Math.pow(worldZ - roundedPlayerZ, 2)
+        );
+
+        // PERFORMANCE FIX: Strict distance check without buffer
+        if (distanceToPlayer <= maxRenderDistance) {
+          const seed = ((x & 0xFFFF) << 16) | (z & 0xFFFF);
+
+          chunks.push({
+            id: `chunk_${x}_${z}`,
+            x,
+            z,
+            worldX,
+            worldZ,
+            seed: Math.abs(seed) % 10000
+          });
+
+          chunkCount++;
         }
       }
     }

--- a/src/components/Fantasy3DUpgradeWorld.tsx
+++ b/src/components/Fantasy3DUpgradeWorld.tsx
@@ -1,6 +1,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { Canvas } from '@react-three/fiber';
+import { FrameLimiter } from './FrameLimiter';
 import { useFantasy3DUpgradeWorld } from './hooks/useFantasy3DUpgradeWorld';
 import { Fantasy3DScene } from './Fantasy3DScene';
 import { Fantasy3DUpgradePedestals } from './Fantasy3DUpgradePedestals';
@@ -97,10 +98,11 @@ export const Fantasy3DUpgradeWorld: React.FC<Fantasy3DUpgradeWorldProps> = ({
         )}
         {isCanvasReady && assetsLoaded && (
           <Canvas
+            frameloop="demand"
             key="fantasy-canvas"
             dpr={[1, 1]}
-            camera={{ 
-              position: [0, 5, 12], 
+            camera={{
+              position: [0, 5, 12],
               fov: 50,
               near: 0.1,
               far: 1200
@@ -115,6 +117,7 @@ export const Fantasy3DUpgradeWorld: React.FC<Fantasy3DUpgradeWorldProps> = ({
               state.camera.updateProjectionMatrix();
             }}
           >
+            <FrameLimiter fps={60} />
             <Fantasy3DScene
               cameraPosition={cameraPosition}
               onPositionChange={handlePositionChange}

--- a/src/components/FogBasedChunkSystem.tsx
+++ b/src/components/FogBasedChunkSystem.tsx
@@ -74,9 +74,9 @@ export const FogBasedChunkSystem: React.FC<FogBasedChunkSystemProps> = React.mem
     let chunkCount = 0;
     const maxChunks = 80; // Increased for smooth transitions
     
-    // Generate chunks with fog-based opacity
+    // Generate chunks with fog-based opacity only ahead of the player
     for (let x = playerChunkX - chunkRadius; x <= playerChunkX + chunkRadius && chunkCount < maxChunks; x++) {
-      for (let z = playerChunkZ - chunkRadius; z <= playerChunkZ + farAheadChunks && chunkCount < maxChunks; z++) {
+      for (let z = playerChunkZ; z <= playerChunkZ + farAheadChunks && chunkCount < maxChunks; z++) {
         const worldX = x * chunkSize;
         const worldZ = -z * chunkSize;
         

--- a/src/components/FrameLimiter.tsx
+++ b/src/components/FrameLimiter.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useThree } from '@react-three/fiber';
+
+interface FrameLimiterProps {
+  fps?: number;
+}
+
+/**
+ * Component that limits render updates to a fixed FPS by
+ * invalidating the Three.js canvas at the desired interval.
+ */
+export const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 60 }) => {
+  const { invalidate } = useThree();
+
+  useEffect(() => {
+    const interval = setInterval(() => invalidate(), 1000 / fps);
+    return () => clearInterval(interval);
+  }, [fps, invalidate]);
+
+  return null;
+};

--- a/src/components/InfinitePathSystem.tsx
+++ b/src/components/InfinitePathSystem.tsx
@@ -52,7 +52,7 @@ const PathSegment: React.FC<PathSegmentProps> = ({
   const position: [number, number, number] = useMemo(() => [
     0, // Centered on X
     0, // Grounded at Y = 0
-    index * pathLength // Repeated along Z-axis
+    -index * pathLength // Repeated along negative Z-axis so the path spawns ahead
   ], [index, pathLength]);
 
   // Calculate bounding box when model loads

--- a/src/components/LinearForestCorridor.tsx
+++ b/src/components/LinearForestCorridor.tsx
@@ -76,7 +76,7 @@ export const LinearForestCorridor: React.FC<LinearForestCorridorProps> = ({
       
       elements.push({
         type: leftTreeType,
-        position: [leftX, -1, z],
+        position: [leftX, -1, -z],
         rotation: [0, seededRandom(z * 567) * Math.PI * 2, 0],
         scale: [leftScale, leftScale, leftScale]
       });
@@ -88,7 +88,7 @@ export const LinearForestCorridor: React.FC<LinearForestCorridorProps> = ({
       
       elements.push({
         type: rightTreeType,
-        position: [rightX, -1, z],
+        position: [rightX, -1, -z],
         rotation: [0, seededRandom(z * 678) * Math.PI * 2, 0],
         scale: [rightScale, rightScale, rightScale]
       });
@@ -99,7 +99,7 @@ export const LinearForestCorridor: React.FC<LinearForestCorridorProps> = ({
         const farLeftX = -pathWidth - 8 - seededRandom(z * 111) * 6;
         elements.push({
           type: seededRandom(z * 222) > 0.5 ? 'tree1' : 'tree2',
-          position: [farLeftX, -1, z + seededRandom(z * 333) * 3],
+          position: [farLeftX, -1, -(z + seededRandom(z * 333) * 3)],
           rotation: [0, seededRandom(z * 444) * Math.PI * 2, 0],
           scale: [0.6 + seededRandom(z * 555) * 0.4, 0.6 + seededRandom(z * 555) * 0.4, 0.6 + seededRandom(z * 555) * 0.4]
         });
@@ -108,7 +108,7 @@ export const LinearForestCorridor: React.FC<LinearForestCorridorProps> = ({
         const farRightX = pathWidth + 8 + seededRandom(z * 666) * 6;
         elements.push({
           type: seededRandom(z * 777) > 0.5 ? 'tree1' : 'tree2',
-          position: [farRightX, -1, z + seededRandom(z * 888) * 3],
+          position: [farRightX, -1, -(z + seededRandom(z * 888) * 3)],
           rotation: [0, seededRandom(z * 999) * Math.PI * 2, 0],
           scale: [0.6 + seededRandom(z * 111) * 0.4, 0.6 + seededRandom(z * 111) * 0.4, 0.6 + seededRandom(z * 111) * 0.4]
         });
@@ -122,7 +122,7 @@ export const LinearForestCorridor: React.FC<LinearForestCorridorProps> = ({
         const detailType = seededRandom(z * 2222) > 0.6 ? 'log' : `rock${Math.floor(seededRandom(z * 3333) * 3) + 1}`;
         elements.push({
           type: detailType,
-          position: [-pathWidth - 1 - seededRandom(z * 4444) * 2, -1, z],
+          position: [-pathWidth - 1 - seededRandom(z * 4444) * 2, -1, -z],
           rotation: [0, seededRandom(z * 5555) * Math.PI * 2, 0],
           scale: [0.8 + seededRandom(z * 6666) * 0.4, 0.8 + seededRandom(z * 6666) * 0.4, 0.8 + seededRandom(z * 6666) * 0.4]
         });
@@ -133,7 +133,7 @@ export const LinearForestCorridor: React.FC<LinearForestCorridorProps> = ({
         const detailType = seededRandom(z * 8888) > 0.6 ? 'log' : `rock${Math.floor(seededRandom(z * 9999) * 3) + 1}`;
         elements.push({
           type: detailType,
-          position: [pathWidth + 1 + seededRandom(z * 1212) * 2, -1, z],
+          position: [pathWidth + 1 + seededRandom(z * 1212) * 2, -1, -z],
           rotation: [0, seededRandom(z * 1313) * Math.PI * 2, 0],
           scale: [0.8 + seededRandom(z * 1414) * 0.4, 0.8 + seededRandom(z * 1414) * 0.4, 0.8 + seededRandom(z * 1414) * 0.4]
         });
@@ -149,7 +149,7 @@ export const LinearForestCorridor: React.FC<LinearForestCorridorProps> = ({
         if (seededRandom(z * (1717 + side)) > 0.5) {
           elements.push({
             type: 'grass',
-            position: [grassX, -1, z + seededRandom(z * (1818 + side)) * 2],
+            position: [grassX, -1, -(z + seededRandom(z * (1818 + side)) * 2)],
             rotation: [0, seededRandom(z * (1919 + side)) * Math.PI * 2, 0],
             scale: [0.6 + seededRandom(z * (2020 + side)) * 0.6, 0.6 + seededRandom(z * (2020 + side)) * 0.6, 0.6 + seededRandom(z * (2020 + side)) * 0.6]
           });


### PR DESCRIPTION
## Summary
- limit rendering to 60 FPS using new `FrameLimiter`
- spawn path segments on the forward axis
- adjust linear forest to match forward direction
- load only forward chunks in chunk systems

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687fe10648e8832e8eff51890ef39f81