### PR TITLE
Fix lint issues in sci-fi upgrade logic

### DIFF
--- a/src/components/SciFiUpgradeManager.tsx
+++ b/src/components/SciFiUpgradeManager.tsx
@@ -63,7 +63,7 @@ export const SciFiUpgradeManager: React.FC<SciFiUpgradeManagerProps> = ({
           required: Math.floor((unlockCondition.requirement as number) / 1000),
           label: 'Time in Layer (seconds)'
         };
-      case 'cannon':
+      case 'cannon': {
         const cannons = Object.values(cannonProgress);
         if (unlockCondition.requirement === 'maxUpgrade') {
           const maxTier = Math.max(0, ...cannons.map(c => c.tier));
@@ -86,6 +86,7 @@ export const SciFiUpgradeManager: React.FC<SciFiUpgradeManagerProps> = ({
           required: unlockCondition.requirement as number,
           label: 'Cannons Upgraded'
         };
+      }
       case 'boss':
         return {
           current: defeatedBosses.includes(unlockCondition.requirement as string) ? 1 : 0,

--- a/src/components/ScifiLayerEffects.tsx
+++ b/src/components/ScifiLayerEffects.tsx
@@ -40,7 +40,7 @@ export const ScifiLayerEffects: React.FC<ScifiLayerEffectsProps> = ({
     // Apply upgrade bonuses
     let speedScale = baseScale.meteorSpeed;
     let lootScale = baseScale.lootDropChance;
-    let difficultyScale = baseScale.difficultyMultiplier;
+    const difficultyScale = baseScale.difficultyMultiplier;
     let stabilityScale = baseScale.platformStability;
 
     // Gravity Anchor Array - Platform stability and slower meteors

--- a/src/data/SciFiUpgradeSystem.ts
+++ b/src/data/SciFiUpgradeSystem.ts
@@ -764,7 +764,7 @@ export const checkUnlockCondition = (
         ? gameState.currentLayer >= unlockCondition.layer && gameState.timeInCurrentLayer >= (unlockCondition.requirement as number)
         : gameState.timeInCurrentLayer >= (unlockCondition.requirement as number);
     
-    case "cannon":
+    case "cannon": {
       const cannons = Object.values(gameState.cannonProgress);
       if (unlockCondition.requirement === "maxUpgrade") {
         return cannons.some(cannon => cannon.tier >= 5);
@@ -773,6 +773,7 @@ export const checkUnlockCondition = (
         return cannons.some(cannon => cannon.abilities.length >= 5);
       }
       return cannons.length >= (unlockCondition.requirement as number);
+    }
     
     case "boss":
       return gameState.defeatedBosses.includes(unlockCondition.requirement as string);


### PR DESCRIPTION
## Summary
- wrap cannon unlock switch cases in braces to allow lexical declarations without lint violations
- mark the sci-fi layer difficulty scale as constant to satisfy lint expectations

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fc3d98d5b4832eacd0677a98126030