### PR TITLE
Add subscription upgrade UI for mobile screens

### DIFF
--- a/apps/mobile/src/components/subscription/SubscriptionCTA.tsx
+++ b/apps/mobile/src/components/subscription/SubscriptionCTA.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import useSubscriptionStatus from '../../hooks/useSubscriptionStatus';
+import { startManageSubscription } from '../../lib/subscriptionActions';
+import { palette } from '../../theme/palette';
+import { spacing, radius } from '../../theme/layout';
+import { typography } from '../../theme/typography';
+
+type SubscriptionCTALocation = 'profile' | 'feed' | 'likes';
+
+interface SubscriptionCTAProps {
+  location: SubscriptionCTALocation;
+}
+
+export const SubscriptionCTA: React.FC<SubscriptionCTAProps> = ({ location }) => {
+  const navigation = useNavigation<any>();
+  const { planId } = useSubscriptionStatus();
+
+  const isFree = planId === 'free';
+  const isPaid = planId === 'plus' || planId === 'pro';
+
+  const handlePress = () => {
+    if (isFree) {
+      navigation.navigate('UpgradePlan');
+      return;
+    }
+
+    startManageSubscription();
+  };
+
+  const captionCopy = isPaid
+    ? `You’re on ${planId === 'plus' ? 'Premium' : 'Elite'}`
+    : location === 'likes'
+    ? 'See more attention with a boost'
+    : 'Unlock more visibility';
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        style={[styles.button, isFree ? styles.primaryButton : styles.destructiveButton]}
+        onPress={handlePress}
+        activeOpacity={0.9}
+      >
+        <Text style={styles.buttonLabel}>{isFree ? 'Upgrade account' : 'Cancel / Downgrade'}</Text>
+      </TouchableOpacity>
+      <Text style={[styles.caption, isPaid && styles.captionPaid]}>{captionCopy}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    marginTop: spacing.md,
+  },
+  button: {
+    paddingVertical: spacing.md,
+    borderRadius: radius.lg,
+    alignItems: 'center',
+  },
+  primaryButton: {
+    backgroundColor: palette.accent,
+  },
+  destructiveButton: {
+    backgroundColor: palette.destructive,
+  },
+  buttonLabel: {
+    color: palette.textPrimary,
+    fontWeight: '600',
+    fontSize: typography.subtitle,
+  },
+  caption: {
+    marginTop: spacing.xs,
+    color: palette.textMuted,
+    fontSize: typography.caption,
+    textAlign: 'center',
+  },
+  captionPaid: {
+    color: palette.textPrimary,
+  },
+});
+
+export default SubscriptionCTA;

--- a/apps/mobile/src/hooks/useSubscriptionStatus.ts
+++ b/apps/mobile/src/hooks/useSubscriptionStatus.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+
+type PlanId = 'free' | 'plus' | 'pro';
+
+export interface SubscriptionStatus {
+  planId: PlanId;
+  planLabel: string;
+  isPaid: boolean;
+  isPro: boolean;
+}
+
+/**
+ * Placeholder hook to represent the user's subscription status.
+ * Update the hardcoded values here once backend wiring is available.
+ */
+export const useSubscriptionStatus = (): SubscriptionStatus => {
+  // TODO: replace with real query to backend/Stripe.
+  const mockPlan: PlanId = 'free';
+
+  return useMemo(() => {
+    const planLabelMap: Record<PlanId, string> = {
+      free: 'Free',
+      plus: 'Premium',
+      pro: 'Elite',
+    };
+
+    return {
+      planId: mockPlan,
+      planLabel: planLabelMap[mockPlan],
+      isPaid: mockPlan !== 'free',
+      isPro: mockPlan === 'pro',
+    };
+  }, [mockPlan]);
+};
+
+export default useSubscriptionStatus;

--- a/apps/mobile/src/lib/subscriptionActions.ts
+++ b/apps/mobile/src/lib/subscriptionActions.ts
@@ -1,0 +1,11 @@
+import { Alert } from 'react-native';
+
+export const startUpgradeFlow = (planId: 'plus' | 'pro') => {
+  console.log(`Starting upgrade flow for plan: ${planId}`);
+  Alert.alert('Upgrade', `Start upgrade flow for ${planId === 'plus' ? 'Premium' : 'Elite'}`);
+};
+
+export const startManageSubscription = () => {
+  console.log('Opening manage subscription portal');
+  Alert.alert('Manage subscription', 'Open manage subscription/portal here');
+};

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import FeedScreen from '../screens/feed/FeedScreen';
+import LikesScreen from '../screens/likes/LikesScreen';
+import ProfileScreen from '../screens/profile/ProfileScreen';
+import UpgradePlanScreen from '../screens/subscription/UpgradePlanScreen';
+
+export type RootStackParamList = {
+  Feed: undefined;
+  Likes: undefined;
+  Profile: undefined;
+  UpgradePlan: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+const AppNavigator: React.FC = () => (
+  <NavigationContainer>
+    <Stack.Navigator initialRouteName="Feed" screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="Feed" component={FeedScreen} />
+      <Stack.Screen name="Likes" component={LikesScreen} />
+      <Stack.Screen name="Profile" component={ProfileScreen} />
+      <Stack.Screen name="UpgradePlan" component={UpgradePlanScreen} />
+    </Stack.Navigator>
+  </NavigationContainer>
+);
+
+export default AppNavigator;

--- a/apps/mobile/src/screens/feed/FeedScreen.tsx
+++ b/apps/mobile/src/screens/feed/FeedScreen.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+import SubscriptionCTA from '../../components/subscription/SubscriptionCTA';
+import { palette } from '../../theme/palette';
+import { spacing, radius } from '../../theme/layout';
+import { typography } from '../../theme/typography';
+
+const FeedScreen: React.FC = () => {
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView contentContainerStyle={styles.container}>
+        <Text style={styles.title}>Feed</Text>
+
+        <View style={styles.exploreSection}>
+          <Text style={styles.sectionTitle}>Explore nearby</Text>
+          <Text style={styles.sectionSubtitle}>See people who are close and active right now.</Text>
+          <View style={styles.placeholderCard}>
+            <Text style={styles.placeholderText}>Explore content placeholder</Text>
+          </View>
+        </View>
+
+        <SubscriptionCTA location="feed" />
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: palette.background,
+  },
+  container: {
+    padding: spacing.xl,
+  },
+  title: {
+    color: palette.textPrimary,
+    fontSize: typography.title,
+    fontWeight: '700',
+    marginBottom: spacing.lg,
+  },
+  exploreSection: {
+    marginBottom: spacing.lg,
+  },
+  sectionTitle: {
+    color: palette.textPrimary,
+    fontSize: typography.subtitle,
+    fontWeight: '700',
+    marginBottom: spacing.xs,
+  },
+  sectionSubtitle: {
+    color: palette.textMuted,
+    marginBottom: spacing.md,
+  },
+  placeholderCard: {
+    backgroundColor: palette.surface,
+    borderRadius: radius.lg,
+    padding: spacing.lg,
+    borderWidth: 1,
+    borderColor: palette.border,
+  },
+  placeholderText: {
+    color: palette.textMuted,
+  },
+});
+
+export default FeedScreen;

--- a/apps/mobile/src/screens/likes/LikesScreen.tsx
+++ b/apps/mobile/src/screens/likes/LikesScreen.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+import SubscriptionCTA from '../../components/subscription/SubscriptionCTA';
+import { palette } from '../../theme/palette';
+import { radius, spacing } from '../../theme/layout';
+import { typography } from '../../theme/typography';
+
+const miniPlanBullets = (bullets: string[]) => (
+  <View style={styles.bulletList}>
+    {bullets.map((bullet) => (
+      <View key={bullet} style={styles.bulletRow}>
+        <Text style={styles.bulletIcon}>•</Text>
+        <Text style={styles.bulletText}>{bullet}</Text>
+      </View>
+    ))}
+  </View>
+);
+
+const LikesScreen: React.FC = () => {
+  const likes = [] as string[]; // placeholder data
+  const hasLikes = likes.length > 0;
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView contentContainerStyle={styles.container}>
+        {hasLikes ? (
+          <Text style={styles.placeholderText}>Here would be your likes list.</Text>
+        ) : (
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyTitle}>No likes yet</Text>
+            <Text style={styles.emptySubtitle}>Upgrade to get seen by more people.</Text>
+
+            <View style={styles.miniCardRow}>
+              <View style={[styles.miniCard, styles.cardSpacing]}>
+                <Text style={styles.miniTitle}>Premium – $8/month</Text>
+                {miniPlanBullets(['3 live posts daily', '10 feed posts daily', 'Extra visibility'])}
+              </View>
+              <View style={[styles.miniCard, styles.miniCardHighlighted]}>
+                <View style={styles.badge}>
+                  <Text style={styles.badgeText}>Most popular</Text>
+                </View>
+                <Text style={styles.miniTitle}>Elite – $20/month</Text>
+                {miniPlanBullets(['10 live posts daily', 'Up to 50 feed posts', 'Top priority'])}
+              </View>
+            </View>
+
+            <SubscriptionCTA location="likes" />
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: palette.background,
+  },
+  container: {
+    padding: spacing.xl,
+  },
+  placeholderText: {
+    color: palette.textMuted,
+  },
+  emptyState: {
+    paddingVertical: spacing.xl,
+  },
+  emptyTitle: {
+    color: palette.textPrimary,
+    fontSize: typography.title,
+    fontWeight: '700',
+    marginBottom: spacing.xs,
+  },
+  emptySubtitle: {
+    color: palette.textMuted,
+    marginBottom: spacing.lg,
+    fontSize: typography.subtitle,
+  },
+  miniCardRow: {
+    flexDirection: 'row',
+  },
+  miniCard: {
+    flex: 1,
+    backgroundColor: palette.surface,
+    borderRadius: radius.lg,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: palette.border,
+  },
+  cardSpacing: {
+    marginRight: spacing.md,
+  },
+  miniCardHighlighted: {
+    borderColor: palette.accent,
+  },
+  miniTitle: {
+    color: palette.textPrimary,
+    fontWeight: '700',
+    marginBottom: spacing.sm,
+  },
+  bulletList: {
+    marginBottom: spacing.sm,
+  },
+  bulletRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.xs,
+  },
+  bulletIcon: {
+    color: palette.accent,
+    marginRight: spacing.xs,
+  },
+  bulletText: {
+    color: palette.textMuted,
+    fontSize: typography.body,
+  },
+  badge: {
+    alignSelf: 'flex-start',
+    backgroundColor: palette.accent,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.md,
+    marginBottom: spacing.xs,
+  },
+  badgeText: {
+    color: palette.textPrimary,
+    fontSize: typography.caption,
+    fontWeight: '700',
+  },
+});
+
+export default LikesScreen;

--- a/apps/mobile/src/screens/profile/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/profile/ProfileScreen.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { SafeAreaView, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import SubscriptionCTA from '../../components/subscription/SubscriptionCTA';
+import { palette } from '../../theme/palette';
+import { radius, spacing } from '../../theme/layout';
+import { typography } from '../../theme/typography';
+
+const ProfileScreen: React.FC = () => {
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView contentContainerStyle={styles.container}>
+        <View style={styles.header}> 
+          <View>
+            <Text style={styles.name}>Your Name</Text>
+            <Text style={styles.subtext}>@username</Text>
+          </View>
+        </View>
+
+        <TouchableOpacity style={styles.editButton} activeOpacity={0.9}>
+          <Text style={styles.editLabel}>Edit Profile</Text>
+        </TouchableOpacity>
+
+        <SubscriptionCTA location="profile" />
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: palette.background,
+  },
+  container: {
+    padding: spacing.xl,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.lg,
+  },
+  name: {
+    color: palette.textPrimary,
+    fontSize: typography.title,
+    fontWeight: '700',
+  },
+  subtext: {
+    color: palette.textMuted,
+    fontSize: typography.body,
+  },
+  editButton: {
+    backgroundColor: palette.accent,
+    paddingVertical: spacing.md,
+    borderRadius: radius.lg,
+    alignItems: 'center',
+  },
+  editLabel: {
+    color: palette.textPrimary,
+    fontWeight: '700',
+    fontSize: typography.subtitle,
+  },
+});
+
+export default ProfileScreen;

--- a/apps/mobile/src/screens/subscription/UpgradePlanScreen.tsx
+++ b/apps/mobile/src/screens/subscription/UpgradePlanScreen.tsx
@@ -1,0 +1,252 @@
+import React from 'react';
+import { LinearGradient } from 'expo-linear-gradient';
+import {
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import useSubscriptionStatus from '../../hooks/useSubscriptionStatus';
+import { startManageSubscription, startUpgradeFlow } from '../../lib/subscriptionActions';
+import { palette } from '../../theme/palette';
+import { radius, spacing } from '../../theme/layout';
+import { typography } from '../../theme/typography';
+
+const UpgradePlanScreen: React.FC = () => {
+  const { planId, planLabel } = useSubscriptionStatus();
+
+  const renderBadge = (label: string) => (
+    <View style={styles.badge}>
+      <Text style={styles.badgeText}>{label}</Text>
+    </View>
+  );
+
+  const renderCard = (
+    plan: 'plus' | 'pro',
+    options: {
+      title: string;
+      price: string;
+      tagline: string;
+      bullets: string[];
+      highlight?: boolean;
+    },
+  ) => {
+    const isCurrent = planId === plan;
+    const cardContent = (
+      <View style={[styles.cardInner, options.highlight && styles.cardHighlighted]}>
+        <View style={styles.cardHeader}>
+          <Text style={styles.cardTitle}>{options.title}</Text>
+          {options.highlight && renderBadge('Most popular')}
+        </View>
+        <Text style={styles.price}>{options.price}</Text>
+        <Text style={styles.tagline}>{options.tagline}</Text>
+        <View style={styles.bulletList}>
+          {options.bullets.map((bullet) => (
+            <View style={styles.bulletRow} key={bullet}>
+              <Text style={styles.bulletIcon}>•</Text>
+              <Text style={styles.bulletText}>{bullet}</Text>
+            </View>
+          ))}
+        </View>
+        <TouchableOpacity
+          style={[styles.ctaButton, isCurrent && styles.ctaButtonDisabled]}
+          disabled={isCurrent}
+          onPress={() => startUpgradeFlow(plan)}
+          activeOpacity={0.9}
+        >
+          <Text style={styles.ctaLabel}>{isCurrent ? 'Current plan' : `Choose ${options.title}`}</Text>
+        </TouchableOpacity>
+      </View>
+    );
+
+    if (options.highlight) {
+      return (
+        <LinearGradient
+          key={plan}
+          colors={[palette.cardGradientStart, palette.cardGradientEnd]}
+          style={styles.card}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+        >
+          {cardContent}
+        </LinearGradient>
+      );
+    }
+
+    return (
+      <View key={plan} style={[styles.card, styles.outlinedCard]}>
+        {cardContent}
+      </View>
+    );
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView contentContainerStyle={styles.container}>
+        {planId !== 'free' && (
+          <View style={styles.currentPlanPill}>
+            <Text style={styles.currentPlanText}>{`You’re currently on ${planLabel}`}</Text>
+          </View>
+        )}
+
+        <Text style={styles.title}>Upgrade your account</Text>
+        <Text style={styles.subtitle}>Get more visibility and more posts per day.</Text>
+
+        {renderCard('plus', {
+          title: 'Premium',
+          price: '$8 / month',
+          tagline: 'Boost your visibility',
+          bullets: ['3 Live Posts per day', '10 Feed Posts per day', 'Increased visibility vs free users'],
+        })}
+
+        {renderCard('pro', {
+          title: 'Elite',
+          price: '$20 / month',
+          tagline: 'Maximum exposure',
+          bullets: ['10 Live Posts per day', 'Up to 50 Feed Posts per day', 'Top visibility priority'],
+          highlight: true,
+        })}
+
+        {planId !== 'free' && (
+          <TouchableOpacity style={styles.manageButton} onPress={startManageSubscription}>
+            <Text style={styles.manageLabel}>Manage subscription</Text>
+          </TouchableOpacity>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: palette.background,
+  },
+  container: {
+    padding: spacing.xl,
+    paddingBottom: spacing.xxl,
+  },
+  title: {
+    color: palette.textPrimary,
+    fontSize: typography.title,
+    fontWeight: '700',
+    marginBottom: spacing.xs,
+  },
+  subtitle: {
+    color: palette.textMuted,
+    fontSize: typography.subtitle,
+    marginBottom: spacing.xl,
+  },
+  card: {
+    borderRadius: radius.xl,
+    padding: 1,
+    backgroundColor: palette.border,
+    marginBottom: spacing.lg,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.2,
+    shadowRadius: 12,
+    elevation: 6,
+  },
+  outlinedCard: {
+    backgroundColor: palette.surface,
+  },
+  cardInner: {
+    backgroundColor: palette.surface,
+    borderRadius: radius.xl,
+    padding: spacing.lg,
+  },
+  cardHighlighted: {
+    backgroundColor: 'transparent',
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.sm,
+  },
+  badge: {
+    backgroundColor: palette.accent,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.md,
+  },
+  badgeText: {
+    color: palette.textPrimary,
+    fontWeight: '700',
+    fontSize: typography.caption,
+  },
+  cardTitle: {
+    color: palette.textPrimary,
+    fontSize: typography.subtitle,
+    fontWeight: '700',
+  },
+  price: {
+    color: palette.textPrimary,
+    fontSize: typography.title,
+    fontWeight: '800',
+    marginBottom: spacing.xs,
+  },
+  tagline: {
+    color: palette.textMuted,
+    fontSize: typography.body,
+    marginBottom: spacing.md,
+  },
+  bulletList: {
+    marginBottom: spacing.lg,
+  },
+  bulletRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  bulletIcon: {
+    color: palette.accent,
+    marginRight: spacing.sm,
+    fontSize: typography.subtitle,
+  },
+  bulletText: {
+    color: palette.textPrimary,
+    fontSize: typography.body,
+  },
+  ctaButton: {
+    backgroundColor: palette.accent,
+    paddingVertical: spacing.md,
+    borderRadius: radius.lg,
+    alignItems: 'center',
+  },
+  ctaButtonDisabled: {
+    backgroundColor: palette.border,
+  },
+  ctaLabel: {
+    color: palette.textPrimary,
+    fontWeight: '700',
+    fontSize: typography.subtitle,
+  },
+  manageButton: {
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+  },
+  manageLabel: {
+    color: palette.textMuted,
+    fontSize: typography.body,
+    textDecorationLine: 'underline',
+  },
+  currentPlanPill: {
+    alignSelf: 'flex-start',
+    backgroundColor: palette.mutedSurface,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.lg,
+    marginBottom: spacing.lg,
+  },
+  currentPlanText: {
+    color: palette.textPrimary,
+    fontSize: typography.caption,
+    fontWeight: '600',
+  },
+});
+
+export default UpgradePlanScreen;

--- a/apps/mobile/src/theme/layout.ts
+++ b/apps/mobile/src/theme/layout.ts
@@ -1,0 +1,15 @@
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24,
+  xxl: 32,
+};
+
+export const radius = {
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24,
+};

--- a/apps/mobile/src/theme/palette.ts
+++ b/apps/mobile/src/theme/palette.ts
@@ -1,0 +1,13 @@
+export const palette = {
+  background: '#0b0b0f',
+  surface: '#12121a',
+  mutedSurface: '#181824',
+  textPrimary: '#f5f5ff',
+  textMuted: '#c5c5d6',
+  accent: '#6c5ce7',
+  accentSecondary: '#8e7bff',
+  border: '#2a2a36',
+  destructive: '#e74c3c',
+  cardGradientStart: '#1f1f2b',
+  cardGradientEnd: '#13131d',
+};

--- a/apps/mobile/src/theme/typography.ts
+++ b/apps/mobile/src/theme/typography.ts
@@ -1,0 +1,6 @@
+export const typography = {
+  title: 24,
+  subtitle: 16,
+  body: 14,
+  caption: 12,
+};


### PR DESCRIPTION
## Summary
- add reusable subscription CTA component driven by mock subscription status and manage/upgrade helpers
- implement upgrade plan screen with premium and elite plan cards and manage CTA for paid users
- integrate upgrade prompts into profile, likes empty state, and feed explore areas with supporting theme tokens and navigation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dcd61c76c832e855c011ab4bb0c71)